### PR TITLE
adds puppy, fixes trace agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,7 @@
 *.zip
 # do not save the dogstatsd binary
 lib/dogstatsd
+lib/puppy
 lib/trace-agent
 venv
+tmp

--- a/bin/compile
+++ b/bin/compile
@@ -12,12 +12,23 @@ mkdir -p $BUILD_DIR/datadog/scripts
 mkdir -p $BUILD_DIR/.profile.d
 
 cp -r $ROOT_DIR/lib/dist $BUILD_DIR/datadog/
+cp -r $ROOT_DIR/lib/conf.d $BUILD_DIR/datadog/
+if [ -f $ROOT_DIR/lib/puppy ]; then
+  cp $ROOT_DIR/lib/puppy $BUILD_DIR/datadog/puppy
+fi
+if [ -f $ROOT_DIR/lib/dogstatsd ]; then
+  cp $ROOT_DIR/lib/dogstatsd $BUILD_DIR/datadog/dogstatsd
+fi
 cp $ROOT_DIR/lib/dogstatsd $BUILD_DIR/datadog/dogstatsd
 cp $ROOT_DIR/lib/trace-agent $BUILD_DIR/datadog/trace-agent
 cp $ROOT_DIR/lib/scripts/get_tags.py $BUILD_DIR/datadog/scripts/get_tags.py
 cp -r $ROOT_DIR/lib/run-datadog.sh $BUILD_DIR/.profile.d/run-datadog.sh
 
-
-chmod +x $BUILD_DIR/datadog/dogstatsd
+if [ -f $BUILD_DIR/datadog/puppy ]; then
+  chmod +x $BUILD_DIR/datadog/puppy
+fi
+if [ -f $BUILD_DIR/datadog/dogstatsd ]; then
+  chmod +x $BUILD_DIR/datadog/dogstatsd
+fi
 chmod +x $BUILD_DIR/datadog/trace-agent
 chmod +x $BUILD_DIR/.profile.d/run-datadog.sh

--- a/build
+++ b/build
@@ -5,19 +5,36 @@ NAME="datadog-cloudfoundry-buildpack"
 ZIPFILE="$NAME.zip"
 PUPPY_DOWNLOAD_URL="https://s3.amazonaws.com/dd-agent/agent6/puppy/linux"
 DOGSTATSD_DOWNLOAD_URL="https://s3.amazonaws.com/dd-agent/dsd6/dogstatsd/linux"
-TRACEAGENT_DOWNLOAD_URL="https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/datadog-agent_5.22.3-1_amd64.deb"
+TRACEAGENT_DOWNLOAD_URL_HEAD="https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/datadog-agent_"
+TRACEAGENT_DOWNLOAD_URL_TAIL="-1_amd64.deb"
+TRACE_DEFAULT_VERSION="6.1.2"
 
 TMPDIR="$SRCDIR/tmp"
 
 
+
 function download_trace_agent() {
+  local trace_version="${1:-$TRACE_DEFAULT_VERSION}"
+  local trace_agent_download_url="$TRACEAGENT_DOWNLOAD_URL_HEAD$trace_version$TRACEAGENT_DOWNLOAD_URL_TAIL"
+
+  local archiver="tar"
+  if command -v gtar > /dev/null 2>&1; then
+    archiver="gtar"
+  else
+    if [[ `uname` == 'Darwin' ]]; then
+      echo "On OSX you might see some errors from untarring the deb package"
+      echo "Using gnu tar will resolve them"
+      echo "However, they should be okay to ignore"
+    fi
+  fi
+
   mkdir -p $TMPDIR
-  curl -L $TRACEAGENT_DOWNLOAD_URL -o ./tmp/datadog-agent.deb
+  curl -L $trace_agent_download_url -o ./tmp/datadog-agent.deb
   pushd $TMPDIR
     ar x datadog-agent.deb
-    tar -xzf data.tar.gz
+    $archiver -xzf data.tar.gz
   popd
-  cp $TMPDIR/opt/datadog-agent/bin/trace-agent $SRCDIR/lib/trace-agent
+  cp $TMPDIR/opt/datadog-agent/embedded/bin/trace-agent $SRCDIR/lib/trace-agent
   rm -rf $TMPDIR/*
 }
 
@@ -55,7 +72,7 @@ function main() {
 
     # Does not support versioning for now, keep it dumb until trace-agent merge with the Agent6
     # curl -L $TRACEAGENT_DOWNLOAD_URL -o ./lib/trace-agent
-    download_trace_agent
+    download_trace_agent $VERSION
     chmod +x $SRCDIR/lib/trace-agent
   fi
 

--- a/build
+++ b/build
@@ -3,31 +3,68 @@
 SRCDIR=$(cd "$(dirname $0)/." && pwd)
 NAME="datadog-cloudfoundry-buildpack"
 ZIPFILE="$NAME.zip"
+PUPPY_DOWNLOAD_URL="https://s3.amazonaws.com/dd-agent/agent6/puppy/linux"
 DOGSTATSD_DOWNLOAD_URL="https://s3.amazonaws.com/dd-agent/dsd6/dogstatsd/linux"
-TRACEAGENT_DOWNLOAD_URL="https://github.com/DataDog/datadog-trace-agent/releases/download/5.20.0/trace-agent-linux"
+TRACEAGENT_DOWNLOAD_URL="https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/datadog-agent_5.22.3-1_amd64.deb"
 
-if [ ! -f ./lib/dogstatsd ] || [ ! -f ./lib/trace-agent ]; then
-  DOWNLOAD="true"
-fi
-if [ -n "$REFRESH_ASSETS" ]; then
-  DOWNLOAD="true"
-fi
-if [ -n "$DOWNLOAD" ]; then
-  if [ -n "$VERSION" ]; then
-    DOGSTATSD_DOWNLOAD_URL="$DOGSTATSD_DOWNLOAD_URL/dogstatsd-$VERSION"
-  else
-    DOGSTATSD_DOWNLOAD_URL="$DOGSTATSD_DOWNLOAD_URL/dogstatsd-latest"
+TMPDIR="$SRCDIR/tmp"
+
+
+function download_trace_agent() {
+  mkdir -p $TMPDIR
+  curl -L $TRACEAGENT_DOWNLOAD_URL -o ./tmp/datadog-agent.deb
+  pushd $TMPDIR
+    ar x datadog-agent.deb
+    tar -xzf data.tar.gz
+  popd
+  cp $TMPDIR/opt/datadog-agent/bin/trace-agent $SRCDIR/lib/trace-agent
+  rm -rf $TMPDIR/*
+}
+
+function main() {
+  if [ ! -f $SRCDIR/lib/dogstatsd ] || [ ! -f $SRCDIR/lib/trace-agent ]; then
+    DOWNLOAD="true"
+  fi
+  if [ -n "$PUPPY" ] && [ ! -f $SRCDIR/lib/puppy ]; then
+    DOWNLOAD="true"
+  fi
+  if [ -n "$REFRESH_ASSETS" ]; then
+    DOWNLOAD="true"
+  fi
+  if [ -n "$DOWNLOAD" ]; then
+    # Delete the old ones
+    rm -f $SRCDIR/lib/puppy
+    rm -f $SRCDIR/lib/dogstatsd
+    rm -f $SRCDIR/lib/trace-agent
+
+    if [ -n "$VERSION" ]; then
+      PUPPY_DOWNLOAD_URL="$PUPPY_DOWNLOAD_URL/agent-$VERSION"
+      DOGSTATSD_DOWNLOAD_URL="$DOGSTATSD_DOWNLOAD_URL/dogstatsd-$VERSION"
+    else
+      PUPPY_DOWNLOAD_URL="$PUPPY_DOWNLOAD_URL/agent-latest"
+      DOGSTATSD_DOWNLOAD_URL="$DOGSTATSD_DOWNLOAD_URL/dogstatsd-latest"
+    fi
+
+    if [ -n "$PUPPY" ]; then
+      curl $PUPPY_DOWNLOAD_URL -o $SRCDIR/lib/puppy
+      chmod +x $SRCDIR/lib/puppy
+    fi
+
+    curl $DOGSTATSD_DOWNLOAD_URL -o ./lib/dogstatsd
+    chmod +x $SRCDIR/lib/dogstatsd
+
+    # Does not support versioning for now, keep it dumb until trace-agent merge with the Agent6
+    # curl -L $TRACEAGENT_DOWNLOAD_URL -o ./lib/trace-agent
+    download_trace_agent
+    chmod +x $SRCDIR/lib/trace-agent
   fi
 
-  curl $DOGSTATSD_DOWNLOAD_URL -o ./lib/dogstatsd
-  # Does not support versioning for now, keep it dumb until trace-agent merge with the Agent6
-  curl -L $TRACEAGENT_DOWNLOAD_URL -o ./lib/trace-agent
-  chmod +x ./lib/dogstatsd
-  chmod +x ./lib/trace-agent
-fi
+  rm -f $ZIPFILE
 
-rm -f $ZIPFILE
+  pushd $SRCDIR
+    zip -r "$ZIPFILE" lib bin
+  popd
+}
 
-pushd $SRCDIR
-  zip -r "$ZIPFILE" lib bin
-popd
+
+main

--- a/lib/conf.d/apm.yaml.default
+++ b/lib/conf.d/apm.yaml.default
@@ -1,0 +1,6 @@
+instances:
+- {} # default instance, if you need to customize its configuration, please comment out this instance
+     # and customize the configuration options on the instance below
+
+#   # path to trace agent binary, defaults to `embedded/bin/trace-agent` in agent installation dir
+# - bin_path: /opt/datadog-agent/embedded/bin/trace-agent

--- a/lib/conf.d/cpu.d/conf.yaml.default
+++ b/lib/conf.d/cpu.d/conf.yaml.default
@@ -1,0 +1,2 @@
+instances:
+  - {}

--- a/lib/conf.d/docker.d/conf.yaml.example
+++ b/lib/conf.d/docker.d/conf.yaml.example
@@ -1,0 +1,73 @@
+init_config:
+
+instances:
+  - ## The agent honors the DOCKER_HOST, DOCKER_CERT_PATH and DOCKER_TLS_VERIFY
+    ## environment variables to setup the connection to the server.
+    ## See https://docs.docker.com/engine/reference/commandline/cli/#environment-variables
+
+    ## Data collection
+    ##
+
+    # Create events whenever a container status change.
+    # Defaults to true.
+    #
+    # collect_events: false
+
+    # By default we do not collect events with a status ['top', 'exec_start', 'exec_create'].
+    # Here can be added additional statuses to be filtered.
+    # List of available statuses can be found here https://docs.docker.com/engine/reference/commandline/events/#object-types
+    # filtered_event_types:
+    #    - 'top'
+    #    - 'exec_start'
+    #    - 'exec_create'
+
+    # Collect disk usage per container with docker.container.size_rw and
+    # docker.container.size_rootfs metrics.
+    # Warning: This might take time for Docker daemon to generate,
+    # ensure that `docker ps -a -q` run fast before enabling it.
+    # Defaults to false.
+    #
+    # collect_container_size: true
+
+    # Collect images stats
+    # Number of available active images and intermediate images as gauges.
+    # Defaults to false.
+    #
+    # collect_images_stats: true
+
+    # Collect disk usage per image with docker.image.size and docker.image.virtual_size metrics.
+    # The check gets this size with the `docker images` command.
+    # Requires collect_images_stats to be enabled.
+    # Defaults to false.
+    #
+    # collect_image_size: true
+
+    # Collect disk metrics (total, used, free) through the docker info command for data and metadata.
+    # This is useful when these values can't be obtained by the disk check.
+    # Example: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-optimized_AMI.html
+    # Note that it only works when the storage driver is devicemapper.
+    # Explanation of these metrics can be found here:
+    # https://github.com/docker/docker/blob/v1.11.1/daemon/graphdriver/devmapper/README.md
+    # Defaults to false.
+    #
+    # collect_disk_stats: true
+
+    # Monitor exiting containers and send service checks based on exit code value
+    # (OK if 0, CRITICAL otherwise)
+    # Defaults to false.
+    #
+    # collect_exit_codes: true
+
+    # Allows ad-hoc spike filtering if the system reports incorrect metrics.
+    # This will drop points if the computed rate is higher than the cap value
+    # capped_metrics:
+    #   docker.cpu.user: 1000
+    #   docker.cpu.system: 1000
+
+    ## Tagging
+    ##
+
+    # You can add extra tags to your Docker metrics with the tags list option.
+    # Example: ["extra_tag", "env:testing"]
+    #
+    # tags: []

--- a/lib/conf.d/file_handle.d/conf.yaml.default
+++ b/lib/conf.d/file_handle.d/conf.yaml.default
@@ -1,0 +1,2 @@
+instances:
+- {}

--- a/lib/conf.d/go_expvar.d/agent_stats.yaml.example
+++ b/lib/conf.d/go_expvar.d/agent_stats.yaml.example
@@ -1,0 +1,133 @@
+init_config:
+instances:
+  # Most memstats metrics are exported by default
+  # See http://godoc.org/runtime#MemStats for their explanation
+  # Note that you can specify a `type` for the metrics. One of:
+  #  * counter
+  #  * gauge (the default)
+  #  * rate (note that this will show up as a gauge in Datadog that is meant to be seen as a "per second rate")
+
+  # - expvar_url: http://localhost:8080
+  #   namespace: examplenamespace         # The default metric namespace is 'go_expvar', define your own
+  #   tags:
+  #     - "application_name:myapp"
+  #     - "optionaltag2"
+  #   metrics:
+  #     # These metrics are just here as examples.
+  #     # Most memstats metrics are collected by default without configuration needed.
+  #     - path: memstats/PauseTotalNs
+  #       alias: go_expvar.gc.pause_time_in_ns
+  #       type: rate
+  #       tags:
+  #         - "metric_tag1:tag_value1"
+  #         - "metric_tag2:tag_value2"
+  #     - path: memstats/Alloc            # metric will be reported as a gauge by default
+  #     - path: memstats/Lookups
+  #       type: rate                      # metric should be reported as a rate instead of the default gauge
+  #     - path: memstats/Mallocs          # with no name specified, the metric name will default to a path based name
+  #       type: counter                   # report as a counter instead of the default gauge
+  #     - path: memstats/Frees
+  #       type: rate
+  #     - path: memstats/BySize/1/Mallocs # You can get nested values by separating them with "/"
+  #     - path: myvariable
+  #       alias: go_expvar.my_custom_name
+  #       type: gauge
+  #     - path: routes/get_.*/count       # You can use a regex when you want to report for all elements matching a certain pattern
+
+
+  # The following instance pulls the go_expvar metrics of the running datadog-agent
+  # Feel free to comment out the instance if you're not interested in these metrics
+  - expvar_url: http://localhost:5000/debug/vars  # if you've defined `expvar_port` in datadog.yaml, change the port here to that value
+    namespace: datadog
+    metrics:
+      # datadog-agent forwarder monitoring
+      - path: forwarder/TransactionsCreated/Series
+        type: rate
+      - path: forwarder/TransactionsCreated/Events
+        type: rate
+      - path: forwarder/TransactionsCreated/ServiceChecks
+        type: rate
+      - path: forwarder/TransactionsCreated/HostMetadata
+        type: rate
+      - path: forwarder/TransactionsCreated/Metadata
+        type: rate
+      - path: forwarder/TransactionsCreated/TimeseriesV1
+        type: rate
+      - path: forwarder/TransactionsCreated/CheckRunsV1
+        type: rate
+      - path: forwarder/TransactionsCreated/IntakeV1
+        type: rate
+      - path: forwarder/TransactionsCreated/Dropped
+        type: rate
+      - path: forwarder/TransactionsCreated/RetryQueueSize
+      - path: forwarder/TransactionsCreated/Requeued
+        type: rate
+      - path: forwarder/TransactionsCreated/Errors
+        type: rate
+      - path: forwarder/TransactionsCreated/Success
+        type: rate
+
+      # datadog-agent dogstatsd monitoring
+      - path: dogstatsd-udp/PacketReadingErrors
+        type: rate
+      - path: dogstatsd-uds/PacketReadingErrors
+        type: rate
+      - path: dogstatsd-uds/OriginDetectionErrors
+        type: rate
+      - path: dogstatsd/ServiceCheckParseErrors
+        type: rate
+      - path: dogstatsd/ServiceCheckPackets
+        type: rate
+      - path: dogstatsd/EventParseErrors
+        type: rate
+      - path: dogstatsd/EventPackets
+        type: rate
+      - path: dogstatsd/MetricParseErrors
+        type: rate
+      - path: dogstatsd/MetricPackets
+        type: rate
+
+      # datadog-agent aggregator monitoring
+      - path: aggregator/Flush/ChecksMetricSampleFlushTime/LastFlush
+      - path: aggregator/Flush/ServiceCheckFlushTime/LastFlush
+      - path: aggregator/Flush/EventFlushTime/LastFlush
+      - path: aggregator/Flush/MetricSketchFlushTime/LastFlush
+      - path: aggregator/Flush/MainFlushTime/LastFlush
+      - path: aggregator/FlushCount/ServiceChecks/LastFlush
+      - path: aggregator/FlushCount/Series/LastFlush
+      - path: aggregator/FlushCount/Events/LastFlush
+      - path: aggregator/FlushCount/Sketches/LastFlush
+      - path: aggregator/SeriesFlushed
+        type: rate
+      - path: aggregator/ServiceCheckFlushed
+        type: rate
+      - path: aggregator/EventsFlushed
+        type: rate
+      - path: aggregator/NumberOfFlush
+        type: rate
+      - path: aggregator/DogstatsdMetricSample
+        type: rate
+      - path: aggregator/ChecksMetricSample
+        type: rate
+      - path: aggregator/ServiceCheck
+        type: rate
+      - path: aggregator/Event
+        type: rate
+      - path: aggregator/HostnameUpdate
+        type: rate
+
+      # datadog-agent scheduler monitoring
+      - path: scheduler/ChecksEntered
+      - path: scheduler/Queues/.*/Size
+        alias: scheduler.queues.size
+      - path: scheduler/Queues/.*/Interval
+        alias: scheduler.queues.interval
+      - path: scheduler/QueuesCount
+
+      # datadog-agent serializer monitoring
+      - path: splitter/NotTooBig
+        type: rate
+      - path: splitter/TooBig
+        type: rate
+      - path: splitter/TotalLoops
+        type: rate

--- a/lib/conf.d/io.d/conf.yaml.default
+++ b/lib/conf.d/io.d/conf.yaml.default
@@ -1,0 +1,2 @@
+instances:
+- {}

--- a/lib/conf.d/jmx.d/conf.yaml.example
+++ b/lib/conf.d/jmx.d/conf.yaml.example
@@ -1,0 +1,57 @@
+init_config:
+  # # Optional, allows specifying custom jars that will be added to the classpath of the agent's JVM,
+  # # BREAKING CHANGE NOTICE : Agent 5.x supported a string if there was only one custom JAR. Since Agent 6, this MUST be a list in all cases
+  # custom_jar_paths:
+  #   - /path/to/custom/jarfile.jar
+  #   - /path/to/another/custom/jarfile2.jar
+
+instances:
+  # - host: localhost
+  #   port: 7199
+  #   user: username
+  #   password: password
+
+  #   # If the agent needs to connect to a non-default JMX URL, specify it here instead of a host and a port
+  #   # If you use this you need to specify a 'name' for the instance, below
+  #   jmx_url: "service:jmx:rmi:///jndi/rmi://myhost.host:9999/custompath"
+
+  #   process_name_regex: .*process_name.* # Instead of specifying a host and port or jmx_url, the agent can connect using the attach api.
+  #                                        # This requires the JDK to be installed and the path to tools.jar to be set below.
+  #   tools_jar_path: /usr/lib/jvm/java-7-openjdk-amd64/lib/tools.jar # To be set when process_name_regex is set
+
+  #   name: jmx_instance
+  #   # java_bin_path: /path/to/java # Optional, should be set if the agent cannot find your java executable
+  #   # java_options: "-Xmx200m -Xms50m" # Optional, Java JVM options
+  #   # trust_store_path: /path/to/trustStore.jks # Optional, should be set if ssl is enabled
+  #   # trust_store_password: password
+  #   # refresh_beans: 600 # Optional (in seconds), default is 600 seconds. Sets refresh period for refreshing matching MBeans list.
+  #                        # Decreasing this value may result in increased CPU usage.
+  #   tags:
+  #     env: stage
+  #     newTag: test
+
+  #   # List of metrics to be collected by the integration
+  #   # Read http://docs.datadoghq.com/integrations/java/ to learn how to customize it
+  #   conf:
+  #     - include:
+  #         domain: my_domain
+  #         bean:
+  #           - my_bean
+  #           - my_second_bean
+  #         attribute:
+  #           attribute1:
+  #             metric_type: counter
+  #             alias: jmx.my_metric_name
+  #           attribute2:
+  #             metric_type: gauge
+  #             alias: jmx.my2ndattribute
+  #     - include:
+  #         domain: 2nd_domain
+  #       exclude:
+  #         bean:
+  #           - excluded_bean
+  #     - include:
+  #         domain_regex: regex_on_domain
+  #       exclude:
+  #         bean_regex:
+  #           - regex_on_excluded_bean

--- a/lib/conf.d/kubernetes_apiserver.d/conf.yaml.example
+++ b/lib/conf.d/kubernetes_apiserver.d/conf.yaml.example
@@ -1,0 +1,13 @@
+init_configs:
+instances:
+  - ## Tagging
+    ##
+
+    # You can add extra tags to your Kubernetes API Server metrics, events and Service Checks with the tags list option.
+    #
+    # tags: ["foo:bar"]
+    #
+    #
+    # You can specify a filter over the event types you want the check to ignore.
+    # See https://github.com/kubernetes/kubernetes/blob/638822fd0f30d9c78e78b91e918cb7364f86b8ab/pkg/kubelet/events/event.go#L20
+    # filtered_event_types: ["MissingClusterDNS"]

--- a/lib/conf.d/load.d/conf.yaml.default
+++ b/lib/conf.d/load.d/conf.yaml.default
@@ -1,0 +1,2 @@
+instances:
+- {}

--- a/lib/conf.d/memory.d/conf.yaml.default
+++ b/lib/conf.d/memory.d/conf.yaml.default
@@ -1,0 +1,2 @@
+instances:
+  - {}

--- a/lib/conf.d/ntp.d/conf.yaml.default
+++ b/lib/conf.d/ntp.d/conf.yaml.default
@@ -1,0 +1,15 @@
+# This file is overwritten upon Agent upgrade.
+# To make modifications to the check configuration, please copy this file
+# to `ntp.yaml` and make your changes on that file.
+
+init_config:
+
+instances:
+  - offset_threshold: 60
+
+    # Optional params:
+    #
+    # host: pool.ntp.org
+    # port: ntp
+    # version: 3
+    # timeout: 5

--- a/lib/conf.d/uptime.d/conf.yaml.default
+++ b/lib/conf.d/uptime.d/conf.yaml.default
@@ -1,0 +1,2 @@
+instances:
+- {}

--- a/lib/run-datadog.sh
+++ b/lib/run-datadog.sh
@@ -9,6 +9,12 @@ start_datadog() {
     export DD_LOG_FILE=$DATADOG_DIR/dogstatsd.log
     export DD_API_KEY
     export DD_DD_URL=https://app.datadoghq.com
+    export DD_ENABLE_CHECKS="${DD_ENABLE_CHECKS:-true}"
+    export DOCKER_DD_AGENT=yes
+
+    if [ "$DD_ENABLE_CHECKS" = "true" ]; then
+      sed -i "s~# confd_path:.*~confd_path: $DATADOG_DIR/conf.d~" $DATADOG_DIR/dist/datadog.yaml
+    fi
 
     # The yaml file requires the tags to be an array,
     # the conf file requires them to be comma separated only
@@ -20,8 +26,17 @@ start_datadog() {
     sed -i "s~# log_file: TRACE_LOG_FILE~log_file: $DATADOG_DIR/trace.log~" $DATADOG_DIR/dist/datadog.conf
     # Override user set tags so the tags set in the yaml file are used instead
     export DD_TAGS=""
-    ./dogstatsd start --cfgpath $DATADOG_DIR/dist/datadog.yaml &
-    ./trace-agent -config $DATADOG_DIR/dist/datadog.conf &
+
+    # DSD requires its own config file
+    cp $DATADOG_DIR/dist/datadog.yaml $DATADOG_DIR/dist/dogstatsd.yaml
+    if [ -n "$RUN_AGENT" -a -f ./puppy ]; then
+      export DD_LOG_FILE=$DATADOG_DIR/agent.log
+      ./puppy start --cfgpath $DATADOG_DIR/dist/ &
+    else
+      export DD_LOG_FILE=$DATADOG_DIR/dogstatsd.log
+      ./dogstatsd start --cfgpath $DATADOG_DIR/dist/ &
+    fi
+    ./trace-agent -ddconfig $DATADOG_DIR/dist/datadog.conf &
   popd
 }
 


### PR DESCRIPTION
This adds the puppy and changes the way we grab the trace agent

The trace agent is currently grabbed through the releases page on github. Raclette stopped putting it up there, so now it will be grabbed from the deb package instead.

This adds the puppy binary to the release, so people who want to be able to use the puppy can do so. It still has dsd in there as well, to provide a lighter weight alternative. I have added logic that should prevent you from using both at once.