### PR TITLE
add multi-buildpack support

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -21,7 +21,6 @@ fi
 if [ -f $ROOT_DIR/lib/dogstatsd ]; then
   cp $ROOT_DIR/lib/dogstatsd $BUILD_DIR/datadog/dogstatsd
 fi
-cp $ROOT_DIR/lib/dogstatsd $BUILD_DIR/datadog/dogstatsd
 cp $ROOT_DIR/lib/trace-agent $BUILD_DIR/datadog/trace-agent
 cp $ROOT_DIR/lib/scripts/get_tags.py $BUILD_DIR/datadog/scripts/get_tags.py
 cp -r $ROOT_DIR/lib/run-datadog.sh $BUILD_DIR/.profile.d/run-datadog.sh

--- a/bin/decorate
+++ b/bin/decorate
@@ -3,4 +3,4 @@
 # Dogstatsd cannot be started from here, so this script cannot do anything
 
 echo "-----> DatadogBuildpack/decorate"
-echo "       \033[0;31mATTENTION: meta-buildpack is getting deprecated by pivotal, please load this buildpack using the multi-buildpack instead.
+echo "       \033[0;31mATTENTION: meta-buildpack is getting deprecated by pivotal, please load this buildpack using the multi-buildpack instead.\e[0m"

--- a/bin/decorate
+++ b/bin/decorate
@@ -1,3 +1,6 @@
 #!/usr/bin/env bash
 
 # Dogstatsd cannot be started from here, so this script cannot do anything
+
+echo "-----> DatadogBuildpack/decorate"
+echo "       \033[0;31mATTENTION: meta-buildpack is getting deprecated by pivotal, please load this buildpack using the multi-buildpack instead.

--- a/bin/supply
+++ b/bin/supply
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-echo "-----> DatadogBuildpack/compile"
+echo "-----> DatadogBuildpack/supply"
 
 BIN_DIR=$(cd $(dirname $0); pwd)
 ROOT_DIR=$(dirname $BIN_DIR)
@@ -8,7 +8,7 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
 
-echo "       Installing Datadog Dogstatsd and Trace Agent"
+echo "Installing Datadog Dogstatsd and Trace Agent"
 
 mkdir -p $BUILD_DIR/datadog/scripts
 mkdir -p $BUILD_DIR/.profile.d

--- a/bin/supply
+++ b/bin/supply
@@ -21,7 +21,6 @@ fi
 if [ -f $ROOT_DIR/lib/dogstatsd ]; then
   cp $ROOT_DIR/lib/dogstatsd $BUILD_DIR/datadog/dogstatsd
 fi
-cp $ROOT_DIR/lib/dogstatsd $BUILD_DIR/datadog/dogstatsd
 cp $ROOT_DIR/lib/trace-agent $BUILD_DIR/datadog/trace-agent
 cp $ROOT_DIR/lib/scripts/get_tags.py $BUILD_DIR/datadog/scripts/get_tags.py
 cp -r $ROOT_DIR/lib/run-datadog.sh $BUILD_DIR/.profile.d/run-datadog.sh


### PR DESCRIPTION
This PR adds Cloud Foundry's CAPI v3 API multi-buildpack support.

For old cf installation that are on older version of the CAPI, pivotal provides a "polyfill" [here](https://github.com/cloudfoundry/multi-buildpack) that will simulate the multi-buildpack functionality. The only drawback is that you'll need a `multi-buildpack.yml` at the root of your app to list the buildpacks to load.

### Testing

I provided a [branch](https://github.com/DataDog/datadog-cloudfoundry-buildpack/tree/arbll/multi-buildpack-bin) containing the agent binaries to ease the testing.

I'll provide example on how to test this against the [hello cf ruby app](https://github.com/DataDog/hello-datadog-cf-ruby).

This needs to be tested in both CAPI v3 and CAPI < v3 scenarios.

---

For CAPI v3 the instructions to use multiple buildpack can be found [here](https://docs.cloudfoundry.org/buildpacks/use-multiple-buildpacks.html). In our case :
```bash
# needs CF CLI to be > v6.34.1
cf push hello-datadog-cf-ruby --no-start -b binary_buildpack
cf v3-push hello-datadog-cf-ruby -b "https://github.com/DataDog/datadog-cloudfoundry-buildpack#arbll/multi-buildpack-bin" -b "https://github.com/cloudfoundry/ruby-buildpack#v1.7.18"
```

Note: As described in the link above this has some drawbacks like no support for the `manifest.yaml`. We should discuss if we support both ways or if we ask everyone to use the polyfill.

---
For CAPI < v3 we need to provide a `multi-buildpack.yml` like [this one](https://github.com/DataDog/hello-datadog-cf-ruby/blob/arbll/multi-buildpack/multi-buildpack.yml). 
To test this you can install the [multi-buildpack polyfill](https://github.com/cloudfoundry/multi-buildpack) and run in the hello-datadog-cf-ruby directory : 
```bash
git checkout arbll/multi-buildpack
cf push hello-datadog-cf-ruby -b "multi-buildpack"
```

