### PR TITLE
Updates the tile type to Buildpack

### DIFF
--- a/tile/tile.yml
+++ b/tile/tile.yml
@@ -8,6 +8,6 @@ apply_open_security_group: false
 
 packages:
 - name: datadog-application-monitoring
-  type: decorator
+  type: buildpack
   path: resources/datadog-cloudfoundry-buildpack.zip
   buildpack_order: 99


### PR DESCRIPTION
With multibuildpack we no longer need the metabuildpack, so it's just a buildpack tile