### PR TITLE
Fixed env var name to start the agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ cf restage $YOUR_APP_NAME
 To start collecting logs from your application in CloudFoundry, the agent contained in the buildpack needs to be activated and log collection enabled.
 
 ```
-cf set-env $YOUR_APP_NAME RUN_PUPPY true
+cf set-env $YOUR_APP_NAME RUN_AGENT true
 cf set-env $YOUR_APP_NAME DD_LOGS_ENABLED true
 # Disable the Agent core checks to disable system metrics collection
 cf set-env $YOUR_APP_NAME DD_ENABLE_CHECKS false


### PR DESCRIPTION
Renamed `RUN_PUPPY` in `RUN_AGENT` in the README. 