### PR TITLE
Revert "Bump buildpack to 6.6.0"

### DIFF
--- a/build
+++ b/build
@@ -7,7 +7,7 @@ PUPPY_DOWNLOAD_URL="https://s3.amazonaws.com/dd-agent/agent6/puppy/linux"
 DOGSTATSD_DOWNLOAD_URL="https://s3.amazonaws.com/dd-agent/dsd6/dogstatsd/linux"
 TRACEAGENT_DOWNLOAD_URL_HEAD="https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/datadog-agent_"
 TRACEAGENT_DOWNLOAD_URL_TAIL="-1_amd64.deb"
-TRACE_DEFAULT_VERSION="6.6.0"
+TRACE_DEFAULT_VERSION="6.5.2"
 
 TMPDIR="$SRCDIR/tmp"
 

--- a/tile/tile-history.yml
+++ b/tile/tile-history.yml
@@ -1,5 +1,4 @@
 ---
 history:
 - 0.9.2
-- 0.9.3
-version: 0.9.4
+version: 0.9.3


### PR DESCRIPTION
Reverts DataDog/datadog-cloudfoundry-buildpack#23