### PR TITLE
Added the possibility to configure the logs-agent with custom configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,25 +29,37 @@ cf restage $YOUR_APP_NAME
 
 #### Log Collection (Beta - No official release yet)
 
-To start collecting logs from your application in CloudFoundry, the agent contained in the buildpack needs to be activated and log collection enabled.
+To start collecting logs from your application in CloudFoundry, use the following configuration:
 
 ```
+# activate the agent
 cf set-env $YOUR_APP_NAME RUN_AGENT true
+# enable log collection
 cf set-env $YOUR_APP_NAME DD_LOGS_ENABLED true
-# Disable the Agent core checks to disable system metrics collection
+# configure the agent to forward logs from stderr and stderr
+cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_TCP_FORWARD_PORT 10514
+cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_CUSTOM_CONFIG [{"type":"tcp","port":"10514","source":"<SOURCE>","service":"<SERVICE>"}]
+# disable the Agent core checks to disable system metrics collection
 cf set-env $YOUR_APP_NAME DD_ENABLE_CHECKS false
 # restage the application to get it to pick up the new environment variable and use the buildpack
 cf restage $YOUR_APP_NAME
 ```
 
-By default, the Agent collects logs from `stdout`/`stderr` and listens to TCP port 10514.
-It is possible to ask the Agent to listen on a different TCP port if you are streaming logs from your application in TCP.
+By default, the Agent collects all logs from `stdout`/`stderr`.
 To disable log collection from `stdout`/`stderr`, use the following configuration:
 
 ```
-# override the TCP port
-cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_TCP_FORWARD_PORT 10514
 # disable log collection on stdout/stderr
+cf set-env $YOUR_APP_NAME DISABLE_STD_LOG_COLLECTION true
+```
+
+Whether you need to send your logs directly from your application, use the following configuration:
+```
+# add custom TCP listener with stdout/stderr forwarding
+cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_TCP_FORWARD_PORT 10514
+cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_CUSTOM_CONFIG [{"type":"tcp","port":"10514","source":"<SOURCE>","service":"<SERVICE>"},{"type":"tcp","port":"<PORT>","source":"<SOURCE>","service":"<SERVICE>"}]
+# add custom TCP listener without stdout/stderr forwarding
+cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_CUSTOM_CONFIG [{"type":"tcp","port":"<PORT>","source":"<SOURCE>","service":"<SERVICE>"}]
 cf set-env $YOUR_APP_NAME DISABLE_STD_LOG_COLLECTION true
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,32 +36,23 @@ To start collecting logs from your application in CloudFoundry, use the followin
 cf set-env $YOUR_APP_NAME RUN_AGENT true
 # enable log collection
 cf set-env $YOUR_APP_NAME DD_LOGS_ENABLED true
-# configure the agent to collect logs from stderr and stderr
-cf set-env $YOUR_APP_NAME STD_LOG_COLLECTION_PORT 10514
-cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_CUSTOM_CONFIG '[{"type":"tcp","port":"10514","source":"<SOURCE>","service":"<SERVICE>"}]'
+# add a custom config
+cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_CUSTOM_CONFIG '[{"type":"tcp","port":"<PORT>","source":"<SOURCE>","service":"<SERVICE>"}]'
 # disable the Agent core checks to disable system metrics collection
 cf set-env $YOUR_APP_NAME DD_ENABLE_CHECKS false
 # restage the application to get it to pick up the new environment variable and use the buildpack
 cf restage $YOUR_APP_NAME
 ```
 
-By default, the Agent collects all logs from `stdout`/`stderr`.
-To disable log collection from `stdout`/`stderr`, use the following configuration:
+Collect logs from stdout/stderr:
 
 ```
-# disable log collection on stdout/stderr
-cf set-env $YOUR_APP_NAME DISABLE_STD_LOG_COLLECTION true
-```
-
-Whether you need to send your logs directly from your application, use the following configuration:
-
-```
-# add custom TCP listener with stdout/stderr forwarding
+# stdout/stderr forwarding only
+cf set-env $YOUR_APP_NAME STD_LOG_COLLECTION_PORT 10514
+cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_CUSTOM_CONFIG '[{"type":"tcp","port":"<PORT>","source":"<SOURCE>","service":"<SERVICE>"}]'
+# stdout/stderr forwarding with additional config
 cf set-env $YOUR_APP_NAME STD_LOG_COLLECTION_PORT 10514
 cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_CUSTOM_CONFIG '[{"type":"tcp","port":"10514","source":"<SOURCE>","service":"<SERVICE>"},{"type":"tcp","port":"<PORT>","source":"<SOURCE>","service":"<SERVICE>"}]'
-# add custom TCP listener without stdout/stderr forwarding
-cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_CUSTOM_CONFIG '[{"type":"tcp","port":"<PORT>","source":"<SOURCE>","service":"<SERVICE>"}]'
-cf set-env $YOUR_APP_NAME DISABLE_STD_LOG_COLLECTION true
 ```
 
 ### DogStatsD Away!

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ To start collecting logs from your application in CloudFoundry, use the followin
 cf set-env $YOUR_APP_NAME RUN_AGENT true
 # enable log collection
 cf set-env $YOUR_APP_NAME DD_LOGS_ENABLED true
-# configure the agent to forward logs from stderr and stderr
-cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_TCP_FORWARD_PORT 10514
+# configure the agent to collect logs from stderr and stderr
+cf set-env $YOUR_APP_NAME STD_LOG_COLLECTION_PORT 10514
 cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_CUSTOM_CONFIG '[{"type":"tcp","port":"10514","source":"<SOURCE>","service":"<SERVICE>"}]'
 # disable the Agent core checks to disable system metrics collection
 cf set-env $YOUR_APP_NAME DD_ENABLE_CHECKS false
@@ -54,9 +54,10 @@ cf set-env $YOUR_APP_NAME DISABLE_STD_LOG_COLLECTION true
 ```
 
 Whether you need to send your logs directly from your application, use the following configuration:
+
 ```
 # add custom TCP listener with stdout/stderr forwarding
-cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_TCP_FORWARD_PORT 10514
+cf set-env $YOUR_APP_NAME STD_LOG_COLLECTION_PORT 10514
 cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_CUSTOM_CONFIG '[{"type":"tcp","port":"10514","source":"<SOURCE>","service":"<SERVICE>"},{"type":"tcp","port":"<PORT>","source":"<SOURCE>","service":"<SERVICE>"}]'
 # add custom TCP listener without stdout/stderr forwarding
 cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_CUSTOM_CONFIG '[{"type":"tcp","port":"<PORT>","source":"<SOURCE>","service":"<SERVICE>"}]'

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ cf set-env $YOUR_APP_NAME RUN_AGENT true
 # enable log collection
 cf set-env $YOUR_APP_NAME DD_LOGS_ENABLED true
 # add a custom config
-cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_CUSTOM_CONFIG '[{"type":"tcp","port":"<PORT>","source":"<SOURCE>","service":"<SERVICE>"}]'
+cf set-env $YOUR_APP_NAME LOGS_CONFIG '[{"type":"tcp","port":"<PORT>","source":"<SOURCE>","service":"<SERVICE>"}]'
 # disable the Agent core checks to disable system metrics collection
 cf set-env $YOUR_APP_NAME DD_ENABLE_CHECKS false
 # restage the application to get it to pick up the new environment variable and use the buildpack
@@ -49,10 +49,10 @@ Collect logs from stdout/stderr:
 ```
 # stdout/stderr forwarding only
 cf set-env $YOUR_APP_NAME STD_LOG_COLLECTION_PORT 10514
-cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_CUSTOM_CONFIG '[{"type":"tcp","port":"<PORT>","source":"<SOURCE>","service":"<SERVICE>"}]'
+cf set-env $YOUR_APP_NAME LOGS_CONFIG '[{"type":"tcp","port":"<PORT>","source":"<SOURCE>","service":"<SERVICE>"}]'
 # stdout/stderr forwarding with additional config
 cf set-env $YOUR_APP_NAME STD_LOG_COLLECTION_PORT 10514
-cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_CUSTOM_CONFIG '[{"type":"tcp","port":"10514","source":"<SOURCE>","service":"<SERVICE>"},{"type":"tcp","port":"<PORT>","source":"<SOURCE>","service":"<SERVICE>"}]'
+cf set-env $YOUR_APP_NAME LOGS_CONFIG '[{"type":"tcp","port":"10514","source":"<SOURCE>","service":"<SERVICE>"},{"type":"tcp","port":"<PORT>","source":"<SOURCE>","service":"<SERVICE>"}]'
 ```
 
 ### DogStatsD Away!

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ cf set-env $YOUR_APP_NAME RUN_AGENT true
 cf set-env $YOUR_APP_NAME DD_LOGS_ENABLED true
 # configure the agent to forward logs from stderr and stderr
 cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_TCP_FORWARD_PORT 10514
-cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_CUSTOM_CONFIG [{"type":"tcp","port":"10514","source":"<SOURCE>","service":"<SERVICE>"}]
+cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_CUSTOM_CONFIG '[{"type":"tcp","port":"10514","source":"<SOURCE>","service":"<SERVICE>"}]'
 # disable the Agent core checks to disable system metrics collection
 cf set-env $YOUR_APP_NAME DD_ENABLE_CHECKS false
 # restage the application to get it to pick up the new environment variable and use the buildpack
@@ -57,9 +57,9 @@ Whether you need to send your logs directly from your application, use the follo
 ```
 # add custom TCP listener with stdout/stderr forwarding
 cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_TCP_FORWARD_PORT 10514
-cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_CUSTOM_CONFIG [{"type":"tcp","port":"10514","source":"<SOURCE>","service":"<SERVICE>"},{"type":"tcp","port":"<PORT>","source":"<SOURCE>","service":"<SERVICE>"}]
+cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_CUSTOM_CONFIG '[{"type":"tcp","port":"10514","source":"<SOURCE>","service":"<SERVICE>"},{"type":"tcp","port":"<PORT>","source":"<SOURCE>","service":"<SERVICE>"}]'
 # add custom TCP listener without stdout/stderr forwarding
-cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_CUSTOM_CONFIG [{"type":"tcp","port":"<PORT>","source":"<SOURCE>","service":"<SERVICE>"}]
+cf set-env $YOUR_APP_NAME DD_LOGS_CONFIG_CUSTOM_CONFIG '[{"type":"tcp","port":"<PORT>","source":"<SOURCE>","service":"<SERVICE>"}]'
 cf set-env $YOUR_APP_NAME DISABLE_STD_LOG_COLLECTION true
 ```
 

--- a/bin/compile
+++ b/bin/compile
@@ -23,6 +23,7 @@ if [ -f $ROOT_DIR/lib/dogstatsd ]; then
 fi
 cp $ROOT_DIR/lib/trace-agent $BUILD_DIR/datadog/trace-agent
 cp $ROOT_DIR/lib/scripts/get_tags.py $BUILD_DIR/datadog/scripts/get_tags.py
+cp $ROOT_DIR/lib/scripts/create_logs_config.py $BUILD_DIR/datadog/scripts/create_logs_config.py
 cp -r $ROOT_DIR/lib/run-datadog.sh $BUILD_DIR/.profile.d/run-datadog.sh
 cp $ROOT_DIR/lib/redirect-logs.sh $BUILD_DIR/.profile.d/redirect-logs.sh
 

--- a/bin/supply
+++ b/bin/supply
@@ -23,6 +23,7 @@ if [ -f $ROOT_DIR/lib/dogstatsd ]; then
 fi
 cp $ROOT_DIR/lib/trace-agent $BUILD_DIR/datadog/trace-agent
 cp $ROOT_DIR/lib/scripts/get_tags.py $BUILD_DIR/datadog/scripts/get_tags.py
+cp $ROOT_DIR/lib/scripts/create_logs_config.py $BUILD_DIR/datadog/scripts/create_logs_config.py
 cp -r $ROOT_DIR/lib/run-datadog.sh $BUILD_DIR/.profile.d/run-datadog.sh
 cp $ROOT_DIR/lib/redirect-logs.sh $BUILD_DIR/.profile.d/redirect-logs.sh
 

--- a/lib/redirect-logs.sh
+++ b/lib/redirect-logs.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
 export DD_LOGS_ENABLED="${DD_LOGS_ENABLED:-false}"
-export DISABLE_STD_LOG_COLLECTION="${DISABLE_STD_LOG_COLLECTION:-false}"
 export DD_LOGS_CONFIG_CUSTOM_CONFIG
 export STD_LOG_COLLECTION_PORT
 
@@ -14,17 +13,13 @@ redirect() {
 
 # setup the redirection from stdout/stderr to the logs-agent.
 if [ "$DD_LOGS_ENABLED" = "true" ]; then
-  if [ -z "DD_LOGS_CONFIG_CUSTOM_CONFIG" ]
+  if [ -z "DD_LOGS_CONFIG_CUSTOM_CONFIG" ]; then
     echo "can't collect logs, DD_LOGS_CONFIG_CUSTOM_CONFIG is not set"
   else
     echo "collect all logs for config $DD_LOGS_CONFIG_CUSTOM_CONFIG"
-    if [ "$DISABLE_STD_LOG_COLLECTION" != "true" ]; then
-      if [ -z "$STD_LOG_COLLECTION_PORT" ]; then
-        echo "can't collect logs on stdout/stderr, STD_LOG_COLLECTION_PORT is not set"
-      else
-        echo "forward all logs from stdout/stderr to agent port $STD_LOG_COLLECTION_PORT"
-        exec &> >(tee >(redirect))
-      fi
+    if [ -n "$STD_LOG_COLLECTION_PORT" ]; then
+      echo "forward all logs from stdout/stderr to agent port $STD_LOG_COLLECTION_PORT"
+      exec &> >(tee >(redirect))
     fi
   fi
 fi

--- a/lib/redirect-logs.sh
+++ b/lib/redirect-logs.sh
@@ -1,19 +1,28 @@
 #!/usr/bin/env bash
 
-export DD_LOGS_CONFIG_TCP_FORWARD_PORT="${DD_LOGS_CONFIG_TCP_FORWARD_PORT:-10514}"
+export DD_LOGS_ENABLED="${DD_LOGS_ENABLED:-false}"
 export DISABLE_STD_LOG_COLLECTION="${DISABLE_STD_LOG_COLLECTION:-false}"
+export DD_LOGS_CONFIG_CUSTOM_CONFIG
+export DD_LOGS_CONFIG_TCP_FORWARD_PORT
 
+# redirect forwards all standard inputs to a TCP socket listening on port DD_LOGS_CONFIG_TCP_FORWARD_PORT.
 redirect() {
   while true; do
     nc localhost $DD_LOGS_CONFIG_TCP_FORWARD_PORT || true
   done
 }
 
+# setup the redirection from stdout/stderr to the logs-agent.
 if [ "$DD_LOGS_ENABLED" = "true" ]; then
-  if [ "$DISABLE_STD_LOG_COLLECTION" != "true" ]; then
-    echo "collect all logs forwarded to stdout/stderr"
-    exec &> >(tee >(redirect))
+  if [ -z "$DD_LOGS_CONFIG_TCP_FORWARD_PORT" ]; then
+    echo "can't collect logs, DD_LOGS_CONFIG_TCP_FORWARD_PORT is not set"
+  elif [ -z "DD_LOGS_CONFIG_CUSTOM_CONFIG" ]
+    echo "can't collect logs, DD_LOGS_CONFIG_CUSTOM_CONFIG is not set"
   else
-    echo "collect all logs forwarded to port $DD_LOGS_CONFIG_TCP_FORWARD_PORT"
+    echo "collect all logs for config $DD_LOGS_CONFIG_CUSTOM_CONFIG"
+    if [ "$DISABLE_STD_LOG_COLLECTION" != "true" ]; then
+      echo "forward all logs from stdout/stderr to agent port $DD_LOGS_CONFIG_TCP_FORWARD_PORT"
+      exec &> >(tee >(redirect))
+    fi
   fi
 fi

--- a/lib/redirect-logs.sh
+++ b/lib/redirect-logs.sh
@@ -3,26 +3,28 @@
 export DD_LOGS_ENABLED="${DD_LOGS_ENABLED:-false}"
 export DISABLE_STD_LOG_COLLECTION="${DISABLE_STD_LOG_COLLECTION:-false}"
 export DD_LOGS_CONFIG_CUSTOM_CONFIG
-export DD_LOGS_CONFIG_TCP_FORWARD_PORT
+export STD_LOG_COLLECTION_PORT
 
-# redirect forwards all standard inputs to a TCP socket listening on port DD_LOGS_CONFIG_TCP_FORWARD_PORT.
+# redirect forwards all standard inputs to a TCP socket listening on port STD_LOG_COLLECTION_PORT.
 redirect() {
   while true; do
-    nc localhost $DD_LOGS_CONFIG_TCP_FORWARD_PORT || true
+    nc localhost $STD_LOG_COLLECTION_PORT || true
   done
 }
 
 # setup the redirection from stdout/stderr to the logs-agent.
 if [ "$DD_LOGS_ENABLED" = "true" ]; then
-  if [ -z "$DD_LOGS_CONFIG_TCP_FORWARD_PORT" ]; then
-    echo "can't collect logs, DD_LOGS_CONFIG_TCP_FORWARD_PORT is not set"
-  elif [ -z "DD_LOGS_CONFIG_CUSTOM_CONFIG" ]
+  if [ -z "DD_LOGS_CONFIG_CUSTOM_CONFIG" ]
     echo "can't collect logs, DD_LOGS_CONFIG_CUSTOM_CONFIG is not set"
   else
     echo "collect all logs for config $DD_LOGS_CONFIG_CUSTOM_CONFIG"
     if [ "$DISABLE_STD_LOG_COLLECTION" != "true" ]; then
-      echo "forward all logs from stdout/stderr to agent port $DD_LOGS_CONFIG_TCP_FORWARD_PORT"
-      exec &> >(tee >(redirect))
+      if [ -z "$STD_LOG_COLLECTION_PORT" ]; then
+        echo "can't collect logs on stdout/stderr, STD_LOG_COLLECTION_PORT is not set"
+      else
+        echo "forward all logs from stdout/stderr to agent port $STD_LOG_COLLECTION_PORT"
+        exec &> >(tee >(redirect))
+      fi
     fi
   fi
 fi

--- a/lib/redirect-logs.sh
+++ b/lib/redirect-logs.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-export DD_LOGS_ENABLED="${DD_LOGS_ENABLED:-false}"
-export DD_LOGS_CONFIG_CUSTOM_CONFIG
+export LOGS_CONFIG
 export STD_LOG_COLLECTION_PORT
 
 # redirect forwards all standard inputs to a TCP socket listening on port STD_LOG_COLLECTION_PORT.
@@ -13,10 +12,10 @@ redirect() {
 
 # setup the redirection from stdout/stderr to the logs-agent.
 if [ "$DD_LOGS_ENABLED" = "true" ]; then
-  if [ -z "DD_LOGS_CONFIG_CUSTOM_CONFIG" ]; then
-    echo "can't collect logs, DD_LOGS_CONFIG_CUSTOM_CONFIG is not set"
+  if [ -z "LOGS_CONFIG" ]; then
+    echo "can't collect logs, LOGS_CONFIG is not set"
   else
-    echo "collect all logs for config $DD_LOGS_CONFIG_CUSTOM_CONFIG"
+    echo "collect all logs for config $LOGS_CONFIG"
     if [ -n "$STD_LOG_COLLECTION_PORT" ]; then
       echo "forward all logs from stdout/stderr to agent port $STD_LOG_COLLECTION_PORT"
       exec &> >(tee >(redirect))

--- a/lib/run-datadog.sh
+++ b/lib/run-datadog.sh
@@ -11,7 +11,10 @@ start_datadog() {
     export DD_DD_URL=${DD_DD_URL:-https://app.datadoghq.com}
     export DD_ENABLE_CHECKS="${DD_ENABLE_CHECKS:-true}"
     export DOCKER_DD_AGENT=yes
-    export DD_LOGS_CONFIG_TCP_FORWARD_PORT="${DD_LOGS_CONFIG_TCP_FORWARD_PORT:-10514}"
+    # use only this parameter to configure the stdout/stderr forward,
+    # the agent tcp forwarding must be properly set in DD_LOGS_CONFIG_CUSTOM_CONFIG
+    # and must match with DD_LOGS_CONFIG_TCP_FORWARD_PORT.
+    export DD_LOGS_CONFIG_TCP_FORWARD_PORT=""
 
     if [ "$DD_ENABLE_CHECKS" = "true" ]; then
       sed -i "s~# confd_path:.*~confd_path: $DATADOG_DIR/conf.d~" $DATADOG_DIR/dist/datadog.yaml

--- a/lib/run-datadog.sh
+++ b/lib/run-datadog.sh
@@ -11,10 +11,6 @@ start_datadog() {
     export DD_DD_URL=${DD_DD_URL:-https://app.datadoghq.com}
     export DD_ENABLE_CHECKS="${DD_ENABLE_CHECKS:-true}"
     export DOCKER_DD_AGENT=yes
-    # use only this parameter to configure the stdout/stderr forward,
-    # the agent tcp forwarding must be properly set in DD_LOGS_CONFIG_CUSTOM_CONFIG
-    # and must match with DD_LOGS_CONFIG_TCP_FORWARD_PORT.
-    export DD_LOGS_CONFIG_TCP_FORWARD_PORT=""
 
     if [ "$DD_ENABLE_CHECKS" = "true" ]; then
       sed -i "s~# confd_path:.*~confd_path: $DATADOG_DIR/conf.d~" $DATADOG_DIR/dist/datadog.yaml

--- a/lib/run-datadog.sh
+++ b/lib/run-datadog.sh
@@ -11,6 +11,7 @@ start_datadog() {
     export DD_DD_URL=${DD_DD_URL:-https://app.datadoghq.com}
     export DD_ENABLE_CHECKS="${DD_ENABLE_CHECKS:-true}"
     export DOCKER_DD_AGENT=yes
+    export LOGS_CONFIG_DIR=$DATADOG_DIR/dist/conf.d/logs.d
     export LOGS_CONFIG
 
     # create and configure set /conf.d if integrations are enabled
@@ -26,8 +27,7 @@ start_datadog() {
 
     # add logs configs
     if [ -n "$LOGS_CONFIG" ]; then
-      export LOGS_CONFIG_DIR=$DATADOG_DIR/dist/conf.d/logs.d
-      mkdir $LOGS_CONFIG_DIR
+      mkdir -p $LOGS_CONFIG_DIR
       python $DATADOG_DIR/scripts/create_logs_config.py
     fi
 

--- a/lib/scripts/create_logs_config.py
+++ b/lib/scripts/create_logs_config.py
@@ -6,8 +6,7 @@ LOGS_CONFIG = os.environ['LOGS_CONFIG']
 config = "{\"logs\":" + LOGS_CONFIG + "}" 
 path = LOGS_CONFIG_DIR + "/logs.yaml"
 
-file = open(path, 'w')
-
-print "writing {} to {}".format(config, path)
-file.write(config)
-file.write("\n")
+with open(path, 'w') as f:
+  print "writing {} to {}".format(config, path)
+  f.write(config)
+  f.write("\n")

--- a/lib/scripts/create_logs_config.py
+++ b/lib/scripts/create_logs_config.py
@@ -1,0 +1,13 @@
+import os
+
+LOGS_CONFIG_DIR = os.environ['LOGS_CONFIG_DIR']
+LOGS_CONFIG = os.environ['LOGS_CONFIG']
+
+config = "{\"logs\":" + LOGS_CONFIG + "}" 
+path = LOGS_CONFIG_DIR + "/logs.yaml"
+
+file = open(path, 'w')
+
+print "writing {} to {}".format(config, path)
+file.write(config)
+file.write("\n")


### PR DESCRIPTION
Added the possibility to configure the logs-agent with custom configs.

This is a breaking change as users must set a TCP forward port and a custom configuration to fully enable collection as opposed to before where they only needed to enable log collection.