### PR TITLE
Added a sleep in redirect to make sure that redirect does not consume all CPU on redirect errors

### DIFF
--- a/lib/redirect-logs.sh
+++ b/lib/redirect-logs.sh
@@ -7,6 +7,7 @@ export STD_LOG_COLLECTION_PORT
 redirect() {
   while true; do
     nc localhost $STD_LOG_COLLECTION_PORT || true
+    sleep 0.5
   done
 }
 


### PR DESCRIPTION
### What does this PR do?

Added a sleep in redirect

### Motivation

Make sure that redirect does not consume all CPU which makes the container crash

### Additional Notes
