### PR TITLE
Use `~` for `sed` command separators for tag replacement

### DIFF
--- a/lib/run-datadog.sh
+++ b/lib/run-datadog.sh
@@ -35,7 +35,7 @@ start_datadog() {
     # the conf file requires them to be comma separated only
     # so they must be grabbed separately
     datadog_tags=$(python $DATADOG_DIR/scripts/get_tags.py)
-    sed -i "s/# tags:.*/tags: $datadog_tags/" $DATADOG_DIR/dist/datadog.yaml
+    sed -i "s~# tags:.*~tags: $datadog_tags~" $DATADOG_DIR/dist/datadog.yaml
     sed -i "s~log_file: TRACE_LOG_FILE~log_file: $DATADOG_DIR/trace.log~" $DATADOG_DIR/dist/datadog.yaml
     if [ -n "$DD_SKIP_SSL_VALIDATION" ]; then
       sed -i "s~# skip_ssl_validation: no~skip_ssl_validation: yes~" $DATADOG_DIR/dist/datadog.yaml


### PR DESCRIPTION
Tags can contain forward slashes `/`, thus breaking the sed command.