### PR TITLE
Post datadog event when log redirection is reset

### DIFF
--- a/lib/redirect-logs.sh
+++ b/lib/redirect-logs.sh
@@ -11,7 +11,8 @@ redirect() {
     nc localhost $STD_LOG_COLLECTION_PORT || sleep 0.5
     echo "Resetting buildpack log redirection"
     if [ "$DD_DEBUG_STD_REDIRECTION" = "true" ]; then
-      curl  -X POST -H "Content-type: application/json" \
+      HTTP_PROXY=$DD_HTTP_PROXY HTTPS_PROXY=$DD_HTTPS_PROXY NO_PROXY=$DD_NO_PROXY curl \
+      -X POST -H "Content-type: application/json" \
       -d "{
             \"title\": \"Resetting buildpack log redirection\",
             \"text\": \"TCP socket on port $STD_LOG_COLLECTION_PORT for log redirection closed. Restarting it.\",

--- a/lib/redirect-logs.sh
+++ b/lib/redirect-logs.sh
@@ -10,14 +10,16 @@ redirect() {
   while true; do
     nc localhost $STD_LOG_COLLECTION_PORT || sleep 0.5
     echo "Resetting buildpack log redirection"
-    curl  -X POST -H "Content-type: application/json" \
-    -d "{
-          \"title\": \"Resetting buildpack log redirection\",
-          \"text\": \"TCP socket on port $STD_LOG_COLLECTION_PORT for log redirection closed. Restarting it.\",
-          \"priority\": \"normal\",
-          \"tags\": $(python $DATADOG_DIR/scripts/get_tags.py),
-          \"alert_type\": \"info\"
-    }" "https://api.datadoghq.com/api/v1/events?api_key=$DD_API_KEY"
+    if [ "$DD_DEBUG_STD_REDIRECTION" = "true" ]; then
+      curl  -X POST -H "Content-type: application/json" \
+      -d "{
+            \"title\": \"Resetting buildpack log redirection\",
+            \"text\": \"TCP socket on port $STD_LOG_COLLECTION_PORT for log redirection closed. Restarting it.\",
+            \"priority\": \"normal\",
+            \"tags\": $(python $DATADOG_DIR/scripts/get_tags.py),
+            \"alert_type\": \"info\"
+      }" "https://api.datadoghq.com/api/v1/events?api_key=$DD_API_KEY"
+    fi
   done
 }
 


### PR DESCRIPTION
Post an event to datadog when the log redirection is reset.
We can lose logs for .5 seconds in such a case, so the event would help correlate missing logs with that.