### PR TITLE
Add support for EU TCP endpoint testing

### DIFF
--- a/lib/redirect-logs.sh
+++ b/lib/redirect-logs.sh
@@ -5,6 +5,14 @@ export STD_LOG_COLLECTION_PORT
 
 DATADOG_DIR="${DATADOG_DIR:-/home/vcap/app/datadog}"
 
+DD_EU_API_SITE="https://api.datadoghq.eu/api/"
+DD_US_API_SITE="https://api.datadoghq.com/api/"
+DD_API_SITE=$DD_US_API_SITE
+
+if [ -n "$DD_SITE" ] && [ "$DD_SITE" = "datadoghq.eu" ]; then
+  DD_API_SITE=$DD_EU_API_SITE
+fi
+
 # redirect forwards all standard inputs to a TCP socket listening on port STD_LOG_COLLECTION_PORT.
 redirect() {
   while true; do
@@ -19,7 +27,7 @@ redirect() {
             \"priority\": \"normal\",
             \"tags\": $(python $DATADOG_DIR/scripts/get_tags.py),
             \"alert_type\": \"info\"
-      }" "https://api.datadoghq.com/api/v1/events?api_key=$DD_API_KEY"
+      }" "${DD_API_SITE}v1/events?api_key=$DD_API_KEY"
     fi
   done
 }

--- a/lib/test-endpoint.sh
+++ b/lib/test-endpoint.sh
@@ -7,19 +7,19 @@ DD_US_API_SITE="https://api.datadoghq.com/api/"
 DD_API_SITE=$DD_US_API_SITE
 DD_USE_EU=false
 
-if [[ -n $DD_SITE ]] && [[ "$DD_SITE" == "datadoghq.eu" ]]; then
+if [ -n "$DD_SITE" ] && [ "$DD_SITE" == "datadoghq.eu" ]; then
   DD_USE_EU=true
   DD_API_SITE=$DD_EU_API_SITE
 fi
 
-if [[ -z "$DD_LOGS_CONFIG_LOGS_DD_URL" ]]; then
+if [ -z "$DD_LOGS_CONFIG_LOGS_DD_URL" ]; then
   # Initialize to default value based on the following order:
   # 1) If both the host/port for logs is specified, use that
   # 2) If DD_SITE is set to datadoghq.eu, use default EU host/port
   # 3) Default back to US logs host/port combo.
-  if [[ -n "$DD_LOGS_CONFIG_DD_PORT" ]] && [[ -n "$DD_LOGS_CONFIG_DD_URL" ]]; then
+  if [ -n "$DD_LOGS_CONFIG_DD_PORT" ] && [ -n "$DD_LOGS_CONFIG_DD_URL" ]; then
     DD_LOGS_CONFIG_LOGS_DD_URL="$DD_LOGS_CONFIG_DD_URL:$DD_LOGS_CONFIG_DD_PORT"
-  elif [[ "$DD_USE_EU" == true ]]; then
+  elif [ "$DD_USE_EU" == true ]; then
     DD_LOGS_CONFIG_LOGS_DD_URL="agent-intake.logs.datadoghq.eu:443"
   else
     DD_LOGS_CONFIG_LOGS_DD_URL="agent-intake.logs.datadoghq.com:10516"

--- a/lib/test-endpoint.sh
+++ b/lib/test-endpoint.sh
@@ -13,8 +13,10 @@ if [[ -n $DD_SITE ]] && [[ "$DD_SITE" == "datadoghq.eu" ]]; then
 fi
 
 if [[ -z "$DD_LOGS_CONFIG_LOGS_DD_URL" ]]; then
-  # Initialize to default value
-  # If DD_SITE contains ".eu" use the EU endpoint, otherwise default to US
+  # Initialize to default value based on the following order:
+  # 1) If both the host/port for logs is specified, use that
+  # 2) If DD_SITE is set to datadoghq.eu, use default EU host/port
+  # 3) Default back to US logs host/port combo.
   if [[ -n "$DD_LOGS_CONFIG_DD_PORT" ]] && [[ -n "$DD_LOGS_CONFIG_DD_URL" ]]; then
     DD_LOGS_CONFIG_LOGS_DD_URL="$DD_LOGS_CONFIG_DD_URL:$DD_LOGS_CONFIG_DD_PORT"
   elif [[ "$DD_USE_EU" == true ]]; then

--- a/lib/test-endpoint.sh
+++ b/lib/test-endpoint.sh
@@ -2,12 +2,12 @@
 
 unset DD_LOGS_VALID_ENDPOINT
 DATADOG_DIR="${DATADOG_DIR:-/home/vcap/app/datadog}"
-DD_US_API_SITE="https://api.datadoghq.eu/api/"
-DD_EU_API_SITE="https://api.datadoghq.us/api/"
+DD_EU_API_SITE="https://api.datadoghq.eu/api/"
+DD_US_API_SITE="https://api.datadoghq.com/api/"
 DD_API_SITE=${DD_US_API_SITE}
 DD_USE_EU=false
 
-if [[ $DD_SITE == *".eu"* ]]; then
+if [ $DD_SITE == "datadog.eu" ]; then
   DD_USE_EU=true
   DD_API_SITE=${DD_EU_API_SITE}
 fi
@@ -19,7 +19,7 @@ if [ -z $DD_LOGS_CONFIG_LOGS_DD_URL ]; then
     DD_LOGS_CONFIG_LOGS_DD_URL="$DD_LOGS_CONFIG_DD_URL:$DD_LOGS_CONFIG_DD_PORT"
   else
     if [[ $DD_USE_EU ]]; then
-      DD_LOGS_CONFIG_LOGS_DD_URL="agent-intake.logs.datadoghq.eu:443"
+      DD_LOGS_CONFIG_LOGS_DD_URL="agent-intake.logs.datadoghq.eu:10516"
     else
         DD_LOGS_CONFIG_LOGS_DD_URL="agent-intake.logs.datadoghq.com:10516"
   fi

--- a/lib/test-endpoint.sh
+++ b/lib/test-endpoint.sh
@@ -2,10 +2,24 @@
 
 unset DD_LOGS_VALID_ENDPOINT
 DATADOG_DIR="${DATADOG_DIR:-/home/vcap/app/datadog}"
+DD_US_API_SITE="https://api.datadoghq.eu/api/"
+DD_EU_API_SITE="https://api.datadoghq.us/api/"
+DD_API_SITE=${DD_US_API_SITE}
+DD_USE_EU=false
+
+if [[ $DD_SITE == *".eu"* ]]; then
+  DD_USE_EU=true
+  DD_API_SITE=${DD_EU_API_SITE}
+fi
 
 if [ -z $DD_LOGS_CONFIG_LOGS_DD_URL ]; then
   # Initialize to default value
-  DD_LOGS_CONFIG_LOGS_DD_URL="agent-intake.logs.datadoghq.com:10516"
+  # If DD_SITE contains ".eu" use the EU endpoint, otherwise default to US
+  if [[ $DD_USE_EU ]]; then
+    DD_LOGS_CONFIG_LOGS_DD_URL="agent-intake.logs.datadoghq.eu:443"
+  else
+      DD_LOGS_CONFIG_LOGS_DD_URL="agent-intake.logs.datadoghq.com:10516"
+  fi
 fi
 
 if [ "$DD_LOGS_ENABLED" = "true" -a -n $DD_LOGS_CONFIG_LOGS_DD_URL ]; then
@@ -29,7 +43,7 @@ if [ "$DD_LOGS_ENABLED" = "true" -a -n $DD_LOGS_CONFIG_LOGS_DD_URL ]; then
             \"priority\": \"normal\",
             \"tags\": $(python $DATADOG_DIR/scripts/get_tags.py),
             \"alert_type\": \"error\"
-      }" "https://api.datadoghq.com/api/v1/events?api_key=$DD_API_KEY"
+      }" "${DD_API_SITE}v1/events?api_key=$DD_API_KEY"
   else
     export DD_LOGS_VALID_ENDPOINT="true"
   fi

--- a/lib/test-endpoint.sh
+++ b/lib/test-endpoint.sh
@@ -4,24 +4,23 @@ unset DD_LOGS_VALID_ENDPOINT
 DATADOG_DIR="${DATADOG_DIR:-/home/vcap/app/datadog}"
 DD_EU_API_SITE="https://api.datadoghq.eu/api/"
 DD_US_API_SITE="https://api.datadoghq.com/api/"
-DD_API_SITE=${DD_US_API_SITE}
+DD_API_SITE=$DD_US_API_SITE
 DD_USE_EU=false
 
-if [ $DD_SITE == "datadog.eu" ]; then
+if [[ -n $DD_SITE ]] && [[ "$DD_SITE" == "datadoghq.eu" ]]; then
   DD_USE_EU=true
-  DD_API_SITE=${DD_EU_API_SITE}
+  DD_API_SITE=$DD_EU_API_SITE
 fi
 
-if [ -z $DD_LOGS_CONFIG_LOGS_DD_URL ]; then
+if [[ -z "$DD_LOGS_CONFIG_LOGS_DD_URL" ]]; then
   # Initialize to default value
   # If DD_SITE contains ".eu" use the EU endpoint, otherwise default to US
-  if [ -n $DD_LOGS_CONFIG_DD_PORT -a -n $DD_LOGS_CONFIG_DD_URL ]; then
+  if [[ -n "$DD_LOGS_CONFIG_DD_PORT" ]] && [[ -n "$DD_LOGS_CONFIG_DD_URL" ]]; then
     DD_LOGS_CONFIG_LOGS_DD_URL="$DD_LOGS_CONFIG_DD_URL:$DD_LOGS_CONFIG_DD_PORT"
+  elif [[ "$DD_USE_EU" == true ]]; then
+    DD_LOGS_CONFIG_LOGS_DD_URL="agent-intake.logs.datadoghq.eu:443"
   else
-    if [[ $DD_USE_EU ]]; then
-      DD_LOGS_CONFIG_LOGS_DD_URL="agent-intake.logs.datadoghq.eu:10516"
-    else
-        DD_LOGS_CONFIG_LOGS_DD_URL="agent-intake.logs.datadoghq.com:10516"
+    DD_LOGS_CONFIG_LOGS_DD_URL="agent-intake.logs.datadoghq.com:10516"
   fi
 fi
 

--- a/lib/test-endpoint.sh
+++ b/lib/test-endpoint.sh
@@ -7,7 +7,7 @@ DD_US_API_SITE="https://api.datadoghq.com/api/"
 DD_API_SITE=$DD_US_API_SITE
 DD_USE_EU=false
 
-if [ -n "$DD_SITE" ] && [ "$DD_SITE" == "datadoghq.eu" ]; then
+if [ -n "$DD_SITE" ] && [ "$DD_SITE" = "datadoghq.eu" ]; then
   DD_USE_EU=true
   DD_API_SITE=$DD_EU_API_SITE
 fi
@@ -19,7 +19,7 @@ if [ -z "$DD_LOGS_CONFIG_LOGS_DD_URL" ]; then
   # 3) Default back to US logs host/port combo.
   if [ -n "$DD_LOGS_CONFIG_DD_PORT" ] && [ -n "$DD_LOGS_CONFIG_DD_URL" ]; then
     DD_LOGS_CONFIG_LOGS_DD_URL="$DD_LOGS_CONFIG_DD_URL:$DD_LOGS_CONFIG_DD_PORT"
-  elif [ "$DD_USE_EU" == true ]; then
+  elif [ "$DD_USE_EU" = true ]; then
     DD_LOGS_CONFIG_LOGS_DD_URL="agent-intake.logs.datadoghq.eu:443"
   else
     DD_LOGS_CONFIG_LOGS_DD_URL="agent-intake.logs.datadoghq.com:10516"


### PR DESCRIPTION
Rely on the DD_SITE parameter for determining the default of where to test the Logs API. 
Make the default be US if thats not specified.

Use the same approach to know where to send the event. 