### PR TITLE
Support HTTPS EU Logs and allow metric submission to EU via DD_SITE var

### DIFF
--- a/lib/dist/datadog.yaml
+++ b/lib/dist/datadog.yaml
@@ -1,5 +1,5 @@
 # The host of the Datadog intake server to send Agent data to
-dd_url: https://app.datadoghq.com
+# dd_url: https://app.datadoghq.com
 
 # The Datadog api key to associate your Agent's data with your organization.
 # Can be found here:

--- a/lib/run-datadog.sh
+++ b/lib/run-datadog.sh
@@ -8,7 +8,7 @@ start_datadog() {
   pushd $DATADOG_DIR
     export DD_LOG_FILE=$DATADOG_DIR/dogstatsd.log
     export DD_API_KEY
-    export DD_DD_URL=${DD_DD_URL:-https://app.datadoghq.com}
+    export DD_DD_URL
     export DD_ENABLE_CHECKS="${DD_ENABLE_CHECKS:-true}"
     export DOCKER_DD_AGENT=yes
     export LOGS_CONFIG_DIR=$DATADOG_DIR/dist/conf.d/logs.d

--- a/lib/test-endpoint.sh
+++ b/lib/test-endpoint.sh
@@ -7,9 +7,28 @@ DD_US_API_SITE="https://api.datadoghq.com/api/"
 DD_API_SITE=$DD_US_API_SITE
 DD_USE_EU=false
 
+DD_DEFAULT_HTTPS_EU_ENDPOINT="agent-http-intake.logs.datadoghq.eu:443"
+DD_DEFAULT_HTTPS_US_ENDPOINT="agent-http-intake.logs.datadoghq.com:10516"
+DD_DEFAULT_TCP_EU_ENDPOINT"agent-intake.logs.datadoghq.eu:443"
+DD_DEFAULT_TCP_US_ENDPOINT="agent-intake.logs.datadoghq.com:10516"
+
 if [ -n "$DD_SITE" ] && [ "$DD_SITE" = "datadoghq.eu" ]; then
   DD_USE_EU=true
   DD_API_SITE=$DD_EU_API_SITE
+fi
+
+if [ -n "$DD_LOGS_CONFIG_USE_HTTP" ] && [ "$DD_LOGS_CONFIG_USE_HTTP" = true]; then
+  if [ "$DD_USE_EU" = true ]; then
+    "$DEFAULT_LOGS_ENDPOINT"="$DD_DEFAULT_HTTPS_EU_ENDPOINT"
+  else
+    "$DEFAULT_LOGS_ENDPOINT"="$DD_DEFAULT_HTTPS_US_ENDPOINT"
+  fi
+else
+  if [ "$DD_USE_EU" = true ]; then
+    "$DEFAULT_LOGS_ENDPOINT"="$DD_DEFAULT_TCP_EU_ENDPOINT"
+  else
+    "$DEFAULT_LOGS_ENDPOINT"="$DD_DEFAULT_TCP_US_ENDPOINT"
+  fi
 fi
 
 if [ -z "$DD_LOGS_CONFIG_LOGS_DD_URL" ]; then
@@ -19,10 +38,8 @@ if [ -z "$DD_LOGS_CONFIG_LOGS_DD_URL" ]; then
   # 3) Default back to US logs host/port combo.
   if [ -n "$DD_LOGS_CONFIG_DD_PORT" ] && [ -n "$DD_LOGS_CONFIG_DD_URL" ]; then
     DD_LOGS_CONFIG_LOGS_DD_URL="$DD_LOGS_CONFIG_DD_URL:$DD_LOGS_CONFIG_DD_PORT"
-  elif [ "$DD_USE_EU" = true ]; then
-    DD_LOGS_CONFIG_LOGS_DD_URL="agent-intake.logs.datadoghq.eu:443"
   else
-    DD_LOGS_CONFIG_LOGS_DD_URL="agent-intake.logs.datadoghq.com:10516"
+    DD_LOGS_CONFIG_LOGS_DD_URL="$DEFAULT_LOGS_ENDPOINT"
   fi
 fi
 

--- a/lib/test-endpoint.sh
+++ b/lib/test-endpoint.sh
@@ -12,12 +12,12 @@ DD_DEFAULT_HTTPS_US_ENDPOINT="agent-http-intake.logs.datadoghq.com:10516"
 DD_DEFAULT_TCP_EU_ENDPOINT"agent-intake.logs.datadoghq.eu:443"
 DD_DEFAULT_TCP_US_ENDPOINT="agent-intake.logs.datadoghq.com:10516"
 
-if [ -n "$DD_SITE" ] && [ "$DD_SITE" = "datadoghq.eu" ]; then
+if [ "$DD_SITE" = "datadoghq.eu" ]; then
   DD_USE_EU=true
   DD_API_SITE=$DD_EU_API_SITE
 fi
 
-if [ -n "$DD_LOGS_CONFIG_USE_HTTP" ] && [ "$DD_LOGS_CONFIG_USE_HTTP" = true]; then
+if [ "$DD_LOGS_CONFIG_USE_HTTP" = true]; then
   if [ "$DD_USE_EU" = true ]; then
     "$DEFAULT_LOGS_ENDPOINT"="$DD_DEFAULT_HTTPS_EU_ENDPOINT"
   else


### PR DESCRIPTION
Adds support for the new `DD_LOGS_CONFIG_USE_HTTP` variable and changes the intake url:port accordingly

Also stops hard coding the default DD_DD_URL variable since we can now just use `DD_SITE`. If you set DD_SITE to `datadoghq.eu` before, but didn't change DD_URL manually, you wouldn't see metrics because they were attempting to go to `.com`. This fixes that. 