### PR TITLE
Update port and use DD_PROXY for logs testing

### DIFF
--- a/lib/test-endpoint.sh
+++ b/lib/test-endpoint.sh
@@ -8,7 +8,7 @@ DD_API_SITE=$DD_US_API_SITE
 DD_USE_EU=false
 
 DD_DEFAULT_HTTPS_EU_ENDPOINT="agent-http-intake.logs.datadoghq.eu:443"
-DD_DEFAULT_HTTPS_US_ENDPOINT="agent-http-intake.logs.datadoghq.com:10516"
+DD_DEFAULT_HTTPS_US_ENDPOINT="agent-http-intake.logs.datadoghq.com:443"
 DD_DEFAULT_TCP_EU_ENDPOINT"agent-intake.logs.datadoghq.eu:443"
 DD_DEFAULT_TCP_US_ENDPOINT="agent-intake.logs.datadoghq.com:10516"
 
@@ -18,10 +18,14 @@ if [ "$DD_SITE" = "datadoghq.eu" ]; then
 fi
 
 if [ "$DD_LOGS_CONFIG_USE_HTTP" = true]; then
-  if [ "$DD_USE_EU" = true ]; then
-    "$DEFAULT_LOGS_ENDPOINT"="$DD_DEFAULT_HTTPS_EU_ENDPOINT"
+  if [ -n "$DD_PROXY_HTTPS" ]; then
+    "$DEFAULT_LOGS_ENDPOINT"="$DD_PROXY_HTTPS"
   else
-    "$DEFAULT_LOGS_ENDPOINT"="$DD_DEFAULT_HTTPS_US_ENDPOINT"
+    if [ "$DD_USE_EU" = true ]; then
+      "$DEFAULT_LOGS_ENDPOINT"="$DD_DEFAULT_HTTPS_EU_ENDPOINT"
+    else
+      "$DEFAULT_LOGS_ENDPOINT"="$DD_DEFAULT_HTTPS_US_ENDPOINT"
+    fi
   fi
 else
   if [ "$DD_USE_EU" = true ]; then
@@ -34,8 +38,9 @@ fi
 if [ -z "$DD_LOGS_CONFIG_LOGS_DD_URL" ]; then
   # Initialize to default value based on the following order:
   # 1) If both the host/port for logs is specified, use that
-  # 2) If DD_SITE is set to datadoghq.eu, use default EU host/port
-  # 3) Default back to US logs host/port combo.
+  # 2) If the DD_HTTPS_PROXY is set, use that
+  # 3) If DD_SITE is set to datadoghq.eu, use default EU host/port
+  # 4) Default back to US logs host/port combo.
   if [ -n "$DD_LOGS_CONFIG_DD_PORT" ] && [ -n "$DD_LOGS_CONFIG_DD_URL" ]; then
     DD_LOGS_CONFIG_LOGS_DD_URL="$DD_LOGS_CONFIG_DD_URL:$DD_LOGS_CONFIG_DD_PORT"
   else

--- a/lib/test-endpoint.sh
+++ b/lib/test-endpoint.sh
@@ -7,6 +7,7 @@ DD_US_API_SITE="https://api.datadoghq.com/api/"
 DD_API_SITE=$DD_US_API_SITE
 DD_USE_EU=false
 
+# Default endpoints can be found in DD Docs - https://docs.datadoghq.com/agent/logs/
 DD_DEFAULT_HTTPS_EU_ENDPOINT="agent-http-intake.logs.datadoghq.eu:443"
 DD_DEFAULT_HTTPS_US_ENDPOINT="agent-http-intake.logs.datadoghq.com:443"
 DD_DEFAULT_TCP_EU_ENDPOINT"agent-intake.logs.datadoghq.eu:443"
@@ -59,13 +60,13 @@ if [ "$DD_LOGS_ENABLED" = "true" -a -n $DD_LOGS_CONFIG_LOGS_DD_URL ]; then
   # Check out exit code and export a variable for subsequent scripts to use
   if [ $? -ne 0 ]; then
     export DD_LOGS_VALID_ENDPOINT="false"
-    echo "Could not establish a TCP connection to $DD_LOGS_CONFIG_LOGS_DD_URL."
+    echo "Could not establish a connection to $DD_LOGS_CONFIG_LOGS_DD_URL."
     # Post alert to datadog
     HTTP_PROXY=$DD_HTTP_PROXY HTTPS_PROXY=$DD_HTTPS_PROXY NO_PROXY=$DD_NO_PROXY curl \
       -X POST -H "Content-type: application/json" \
       -d "{
             \"title\": \"Log endpoint cannot be reached - Log collection not started\",
-            \"text\": \"Could not establish a TCP connection to $DD_LOGS_CONFIG_LOGS_DD_URL after 5 seconds. Log collection has not been started.\",
+            \"text\": \"Could not establish a connection to $DD_LOGS_CONFIG_LOGS_DD_URL after 5 seconds. Log collection has not been started.\",
             \"priority\": \"normal\",
             \"tags\": $(python $DATADOG_DIR/scripts/get_tags.py),
             \"alert_type\": \"error\"


### PR DESCRIPTION
The proper port for US HTTPS is 443 - https://docs.datadoghq.com/agent/logs/?tab=tailexistingfiles#send-logs-over-https

Properly use the DD_HTTPS_PROXY environment variable to test with if it was set

Update inline comment to include this detection in the order of how we determine the endpoint to test against. 