### PR TITLE
Standardize the env var naming + strip protocol

### DIFF
--- a/lib/test-endpoint.sh
+++ b/lib/test-endpoint.sh
@@ -6,6 +6,17 @@ DD_EU_API_SITE="https://api.datadoghq.eu/api/"
 DD_US_API_SITE="https://api.datadoghq.com/api/"
 DD_API_SITE=$DD_US_API_SITE
 DD_USE_EU=false
+FOO=${default:-$TEST}
+
+# Sets variable in order of DD_PROXY_HTTP -> DD_HTTP_PROXY -> HTTP_PROXY
+DD_PROXY_HTTP_VAR=${DD_PROXY_HTTP:-$DD_HTTP_PROXY}
+DD_PROXY_HTTP_VAR=${DD_PROXY_HTTP_VAR:-$HTTP_PROXY}
+
+# Sets variable in order of DD_PROXY_HTTPS -> DD_HTTPS_PROXY -> HTTPS_PROXY
+DD_PROXY_HTTPS_VAR=${DD_PROXY_HTTPS:-$DD_HTTPS_PROXY}
+DD_PROXY_HTTPS_VAR=${DD_PROXY_HTTPS_VAR:-$HTTPS_PROXY}
+
+DD_STRIPPED_PROXY_HTTPS="${DD_PROXY_HTTP_VAR//https:\/\/}"
 
 # Default endpoints can be found in DD Docs - https://docs.datadoghq.com/agent/logs/
 DD_DEFAULT_HTTPS_EU_ENDPOINT="agent-http-intake.logs.datadoghq.eu:443"
@@ -19,8 +30,8 @@ if [ "$DD_SITE" = "datadoghq.eu" ]; then
 fi
 
 if [ "$DD_LOGS_CONFIG_USE_HTTP" = true ]; then
-  if [ -n "$DD_PROXY_HTTPS" ]; then
-    DEFAULT_LOGS_ENDPOINT="$DD_PROXY_HTTPS"
+  if [ -n "$DD_STRIPPED_PROXY_HTTPS" ]; then
+    DEFAULT_LOGS_ENDPOINT="$DD_STRIPPED_PROXY_HTTPS"
   else
     if [ "$DD_USE_EU" = true ]; then
       DEFAULT_LOGS_ENDPOINT="$DD_DEFAULT_HTTPS_EU_ENDPOINT"
@@ -39,7 +50,7 @@ fi
 if [ -z "$DD_LOGS_CONFIG_LOGS_DD_URL" ]; then
   # Initialize to default value based on the following order:
   # 1) If both the host/port for logs is specified, use that
-  # 2) If the DD_HTTPS_PROXY is set, use that
+  # 2) If the DD_PROXY_HTTPS is set, use that
   # 3) If DD_SITE is set to datadoghq.eu, use default EU host/port
   # 4) Default back to US logs host/port combo.
   if [ -n "$DD_LOGS_CONFIG_DD_PORT" ] && [ -n "$DD_LOGS_CONFIG_DD_URL" ]; then
@@ -49,7 +60,7 @@ if [ -z "$DD_LOGS_CONFIG_LOGS_DD_URL" ]; then
   fi
 fi
 
-if [ "$DD_LOGS_ENABLED" = "true" -a -n $DD_LOGS_CONFIG_LOGS_DD_URL ]; then
+if [ "$DD_LOGS_ENABLED" = "true" -a -n $DD_LOGS_CONFIG_LOGS_DD_URL -a "$DD_SKIP_LOGS_TEST" != "true" ]; then
   echo "Validating log endpoint $DD_LOGS_CONFIG_LOGS_DD_URL"
   LOGS_ENDPOINT=`echo $DD_LOGS_CONFIG_LOGS_DD_URL | cut -d ":" -f1`
   LOGS_PORT=`echo $DD_LOGS_CONFIG_LOGS_DD_URL | cut -d ":" -f2`
@@ -62,7 +73,7 @@ if [ "$DD_LOGS_ENABLED" = "true" -a -n $DD_LOGS_CONFIG_LOGS_DD_URL ]; then
     export DD_LOGS_VALID_ENDPOINT="false"
     echo "Could not establish a connection to $DD_LOGS_CONFIG_LOGS_DD_URL."
     # Post alert to datadog
-    HTTP_PROXY=$DD_HTTP_PROXY HTTPS_PROXY=$DD_HTTPS_PROXY NO_PROXY=$DD_NO_PROXY curl \
+    HTTP_PROXY=$DD_PROXY_HTTP_VAR HTTPS_PROXY=$DD_PROXY_HTTPS_VAR NO_PROXY=$DD_NO_PROXY curl \
       -X POST -H "Content-type: application/json" \
       -d "{
             \"title\": \"Log endpoint cannot be reached - Log collection not started\",

--- a/lib/test-endpoint.sh
+++ b/lib/test-endpoint.sh
@@ -15,7 +15,7 @@ DD_PROXY_HTTP_VAR=${DD_PROXY_HTTP_VAR:-$HTTP_PROXY}
 DD_PROXY_HTTPS_VAR=${DD_PROXY_HTTPS:-$DD_HTTPS_PROXY}
 DD_PROXY_HTTPS_VAR=${DD_PROXY_HTTPS_VAR:-$HTTPS_PROXY}
 
-DD_STRIPPED_PROXY_HTTPS="${DD_PROXY_HTTP_VAR//https:\/\/}"
+DD_STRIPPED_PROXY_HTTPS="${DD_PROXY_HTTPS_VAR//https:\/\/}"
 
 # Default endpoints can be found in DD Docs - https://docs.datadoghq.com/agent/logs/
 DD_DEFAULT_HTTPS_EU_ENDPOINT="agent-http-intake.logs.datadoghq.eu:443"
@@ -84,4 +84,6 @@ if [ "$DD_LOGS_ENABLED" = "true" -a -n $DD_LOGS_CONFIG_LOGS_DD_URL -a "$DD_SKIP_
   else
     export DD_LOGS_VALID_ENDPOINT="true"
   fi
+else
+  echo "Skipping log endpoint validation"
 fi

--- a/lib/test-endpoint.sh
+++ b/lib/test-endpoint.sh
@@ -16,6 +16,7 @@ DD_PROXY_HTTPS_VAR=${DD_PROXY_HTTPS:-$DD_HTTPS_PROXY}
 DD_PROXY_HTTPS_VAR=${DD_PROXY_HTTPS_VAR:-$HTTPS_PROXY}
 
 DD_STRIPPED_PROXY_HTTPS="${DD_PROXY_HTTPS_VAR//https:\/\/}"
+DD_STRIPPED_PROXY_HTTPS="${DD_STRIPPED_PROXY_HTTPS//http:\/\/}"
 
 # Default endpoints can be found in DD Docs - https://docs.datadoghq.com/agent/logs/
 DD_DEFAULT_HTTPS_EU_ENDPOINT="agent-http-intake.logs.datadoghq.eu:443"

--- a/lib/test-endpoint.sh
+++ b/lib/test-endpoint.sh
@@ -6,7 +6,6 @@ DD_EU_API_SITE="https://api.datadoghq.eu/api/"
 DD_US_API_SITE="https://api.datadoghq.com/api/"
 DD_API_SITE=$DD_US_API_SITE
 DD_USE_EU=false
-FOO=${default:-$TEST}
 
 # Sets variable in order of DD_PROXY_HTTP -> DD_HTTP_PROXY -> HTTP_PROXY
 DD_PROXY_HTTP_VAR=${DD_PROXY_HTTP:-$DD_HTTP_PROXY}


### PR DESCRIPTION
* Strip the https/http proxy protocol when passing into `nc` as `nc` will fail if its included
* Add a bypass option to this test script `DD_SKIP_LOGS_TEST`
* Standardize the http(s) proxy naming convention by allowing both `DD_HTTP_PROXY` and `DD_PROXY_HTTP` (Agent expects the `DD_PROXY_HTTP` style variable - https://docs.datadoghq.com/agent/docker/apm/?tab=java#docker-apm-agent-environment-variables)