### PR TITLE
Update build scripts to point to latest agent version

### DIFF
--- a/build
+++ b/build
@@ -3,11 +3,11 @@
 SRCDIR=$(cd "$(dirname $0)/." && pwd)
 NAME="datadog-cloudfoundry-buildpack"
 ZIPFILE="$NAME.zip"
-PUPPY_DOWNLOAD_URL="https://s3.amazonaws.com/dd-agent/agent6/puppy/linux"
-DOGSTATSD_DOWNLOAD_URL="https://s3.amazonaws.com/dd-agent/dsd6/dogstatsd/linux"
+PUPPY_DOWNLOAD_URL="https://s3.amazonaws.com/dd-agent/agent7/puppy/linux"
+DOGSTATSD_DOWNLOAD_URL="https://s3.amazonaws.com/dd-agent/dsd7/dogstatsd/linux"
 TRACEAGENT_DOWNLOAD_URL_HEAD="https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/datadog-agent_"
 TRACEAGENT_DOWNLOAD_URL_TAIL="-1_amd64.deb"
-TRACE_DEFAULT_VERSION="6.14.0"
+TRACE_DEFAULT_VERSION="7.16.0"
 
 TMPDIR="$SRCDIR/tmp"
 


### PR DESCRIPTION
Starting the release cycle for the latest buildpack to include the latest datadog agent binaries. These are now Agent 7.x binaries and the links to download them are changed, so this PR updates the build scripts. 