### PR TITLE
Add template files for `status` command and fix link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a [decorator buildpack](https://github.com/cf-platform-eng/meta-buildpac
 First, you will have to [install the Meta Buildpack](https://github.com/cf-platform-eng/meta-buildpack#how-to-install-the-meta-buildpack). This enables apps to use decorator buildpacks. Follow the instructions to get the buildpack and upload it if you don't already have it.
 
 ### Upload the buildpack to CF
-- Download the latest Datadog [build pack release](https://cloudfoundry.datadoghq.com/datadog-cloudfoundry-buildpack/datadog-cloudfoundry-buildpack-latest.zip) or [build it](#building). After you have the zipfile, you will have to upload it to Cloud Foundry environment.
+- Download the latest Datadog [build pack release](https://cloudfoundry.datadoghq.com/datadog-cloudfoundry-buildpack/datadog-cloudfoundry-buildpack-latest.zip) or [build it](/DEVELOPMENT.md#building). After you have the zipfile, you will have to upload it to Cloud Foundry environment.
 
 - Create the buildpack in CF if it does not exist
     ```bash

--- a/build
+++ b/build
@@ -33,6 +33,8 @@ function download_trace_agent() {
     $archiver -xzf data.tar.gz
   popd
   cp $TMPDIR/opt/datadog-agent/embedded/bin/trace-agent $SRCDIR/lib/trace-agent
+  # Download the template files that are required for the status command
+  cp -r $TMPDIR/opt/datadog-agent/bin/agent/dist/templates/ $SRCDIR/lib/dist/templates
   rm -rf $TMPDIR/*
 }
 


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.

### What does this PR do?

Fixes the `status` command for the puppy binary in the buildpack. 

Previously when running `/app/datadog/puppy -c /app/datadog/dist/datadog.yaml status` you'd get a panic error about missing templates. With these templates added, the status prints out as expected

Also, quickly fixed a broken link in the README

### Description of the Change

The templates that are shipped with an agent are now copied to this `lib/dist/templates` directory at the same time we download the trace agent + other binaries during the build. They come from the deb package for the trace agent that we download and simply copy them over to the `lib/dist/templates` folder` They are then shipped with the buildpack and available to the end user.

### Alternate Designs

We could take this manually and store the templates folder in git instead of pulling during build time, however doing this during the build process, like it is in this PR, helps ensure you get the templates for the specific agent version you're building with. 

### Verification Process

Built + pushed this buildpack with an example app, ssh-ed in and ran `/app/datadog/puppy -c /app/datadog/dist/datadog.yaml status` and got the full status output. 

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
