### PR TITLE
Bump days before close in stale action and use fork of labeler action

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -6,6 +6,6 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v2
+    - uses: DataDog/labeler@glob-all
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -28,6 +28,7 @@ jobs:
 
             1. Comment that the issue is still reproducible and include updated details requested in the issue template.
         days-before-stale: 30
+        days-before-close: 99999
         stale-issue-label: 'stale'
         exempt-issue-label: 'stale/exempt'
         stale-pr-message: >-


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.

### What does this PR do?

Bumps the days before close in the stale action. This has a default value of `7` if not set, and we want to not close stale issues. 

Also uses the Datadog fork of the labeler action to include some bugfixes and features that aren't yet upstream. 

### Description of the Change

Chooses an arbitrarily large value for `days-before-close` to essentially "never" close stale issues/prs

### Alternate Designs

The stale action doesn't yet support "never" closing an issue, so I don't think there is an alternative here

### Verification Process

No manual tests done here. 

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
