### PR TITLE
Remove templates from the build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 lib/dogstatsd
 lib/puppy
 lib/trace-agent
-lib/dist/templates/
 venv
 tmp
 .DS_Store

--- a/build
+++ b/build
@@ -33,8 +33,6 @@ function download_trace_agent() {
     $archiver -xzf data.tar.gz
   popd
   cp $TMPDIR/opt/datadog-agent/embedded/bin/trace-agent $SRCDIR/lib/trace-agent
-  # Download the template files that are required for the status command
-  cp -r $TMPDIR/opt/datadog-agent/bin/agent/dist/templates/ $SRCDIR/lib/dist/templates
   rm -rf $TMPDIR/*
 }
 


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.

### What does this PR do?

This PR stops shipping the template files with the buildpack (and removes them from the gitignore)
Since this PR in the datadog-agent was merged https://github.com/DataDog/datadog-agent/pull/4782, the template files are included in the agent binary directly and aren't needed here anymore. 

I've tested a custom buildpack with the latest puppy agent off the master branch, and was able to successfully run the status command. 

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
