### PR TITLE
Remove the apm.yml.default file

### DIFF
--- a/lib/conf.d/apm.yaml.default
+++ b/lib/conf.d/apm.yaml.default
@@ -1,6 +1,0 @@
-instances:
-- {} # default instance, if you need to customize its configuration, please comment out this instance
-     # and customize the configuration options on the instance below
-
-#   # path to trace agent binary, defaults to `embedded/bin/trace-agent` in agent installation dir
-# - bin_path: /opt/datadog-agent/embedded/bin/trace-agent


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.

### What does this PR do?

Removes the `apm.yaml.default` file from being shipped with the buildpack

### Description of the Change

This file is no longer needed by the datadog agent (and was actually removed from being shipped with the linux agent's here - https://github.com/DataDog/datadog-agent/pull/1283 a little while back).

We don't need this file because we start the trace agent binary directly - https://github.com/DataDog/datadog-cloudfoundry-buildpack/blob/master/lib/run-datadog.sh#L93

Having this file causes the main agent binary to try and load this as an integration, which leads to both an error in the agent's status page + in the UI.  

Fixes #79 

### Verification Process

Pushed an app with this custom build and no longer see the error in the status page/UI + still get traces as expected from the trace agent. 

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
