### PR TITLE
Windows buildpack and .NET Core (Linux)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@
 lib/dogstatsd
 lib/puppy
 lib/trace-agent
+lib/dotnet-tracer.deb
+lib/dotnet-tracer.msi
+# This is covered by the above *.zip but this is explicit
+lib/agent-binaries.zip
 venv
 tmp
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,6 @@
 lib/dogstatsd
 lib/puppy
 lib/trace-agent
-lib/dist/templates/
 venv
 tmp
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ lib/dogstatsd
 lib/puppy
 lib/trace-agent
 lib/dotnet-tracer.deb
-lib/dotnet-tracer.msi
+lib/dotnet-tracer.zip
 # This is covered by the above *.zip but this is explicit
 lib/agent-binaries.zip
 venv

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 lib/dogstatsd
 lib/puppy
 lib/trace-agent
+lib/dist/templates/
 venv
 tmp
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ cf restage $YOUR_APP_NAME
 ### DogStatsD Away!
 You're all set up to use DogStatsD. Import the relevant library and start sending data! To learn more, [check our our documentation](https://docs.datadoghq.com/guides/DogStatsD/). Additionally, there is [a list of DogStatsD libraries](https://docs.datadoghq.com/libraries/) you can check out to find one that's compatible with your application.
 
+Note: On Windows .NET applications you can add the Dogstatsd-CSharp client to your project's dependencies to submit custom metrics from your application. This requires publishing the application (to include the dogstatsd client dependency) and passing the published folder in your app manifest.
+
 ## Docker
 
 If you're running docker on Cloud Foundry, you can look at [the docker directory](docker/) to see how to adapt this buildpack to use in a dockerfile

--- a/README.md
+++ b/README.md
@@ -103,7 +103,21 @@ To do so, add the path `C:\Users\vcap\app\datadog\dotNetTracer` in the [`probing
 </runtime>
 ```
 
-2. Setup the appropriate environment variables for your application depending on the OS the app will run on.
+2. Setup the appropriate environment variables for your application depending on the OS the app will run on. These can be set directly in the `run.cmd` file.
+
+**example**:
+```
+# Setup the Tracing Environment Variables
+SET COR_ENABLE_PROFILING=1
+SET COR_PROFILER={846F5F1C-F9AE-4B07-969E-05C26BC060D8}
+SET COR_PROFILER_PATH_64=C:\Users\vcap\app\datadog\dotNetTracer\x64\Datadog.Trace.ClrProfiler.Native.dll
+SET COR_PROFILER_PATH_32=C:\Users\vcap\app\datadog\dotNetTracer\x86\Datadog.Trace.ClrProfiler.Native.dll
+SET DD_INTEGRATIONS=\Users\vcap\app\datadog\dotNetTracer\integrations.json
+SET DD_DOTNET_TRACER_HOME=\Users\vcap\app\datadog\dotNetTracer
+SET DD_TRACE_LOG_PATH=\Users\vcap\app\datadog\dotNetTracer\dotnet-profiler.log
+# Redirect logs to the Datadog Agent
+.cloudfoundry\hwc.exe | powershell C:\Users\vcap\app\datadog\scripts\redirect_logs.ps1 2>&1
+```
 
 Alternatively, you can install the [Datadog.Trace.ClrProfiler.Managed Nuget package](https://www.nuget.org/packages/Datadog.Trace.ClrProfiler.Managed) in your app before pushing it to CloudFoundry.
 
@@ -116,23 +130,6 @@ cf set-env $YOUR_APP_NAME DD_API_KEY $YOUR_DATADOG_API_KEY
 # Setting this environment variable will bundle the .NET Tracing dependencies and enable the
 cf set-env $YOUR_APP_NAME DD_DOTNET_TRACING true
 # environment variables needed to automatically instrument your .NET Application
-cf restage $YOUR_APP_NAME
-```
-
-### Windows (.NET Framework Apps)
-
-Set the following environment variables in your application:
-```
-# Set your API key to send traces to Datadog
-cf set-env $YOUR_APP_NAME DD_API_KEY $YOUR_DATADOG_API_KEY
-# Setup the dotnet datadog tracer
-cf set-env $YOUR_APP_NAME COR_ENABLE_PROFILING 1
-cf set-env $YOUR_APP_NAME COR_PROFILER {846F5F1C-F9AE-4B07-969E-05C26BC060D8}
-cf set-env $YOUR_APP_NAME COR_PROFILER_PATH C:\Users\vcap\app\datadog\dotNetTracer\Datadog.Trace.ClrProfiler.Native.dll
-cf set-env $YOUR_APP_NAME DD_TRACE_LOG_PATH "\Users\vcap\app\datadog\dotNetTracer\tracer.log"
-cf set-env $YOUR_APP_NAME DD_INTEGRATIONS "\Users\vcap\app\datadog\dotNetTracer\integrations.json"
-cf set-env $YOUR_APP_NAME DD_TRACE_ENABLED true
-# Restage your app to take these changes
 cf restage $YOUR_APP_NAME
 ```
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,9 @@ All the options supported by the Agent in the main configuration file (`lib/dist
 
 #### .NET Traces
 
-The buildpack also includes the [.NET Tracer](https://docs.datadoghq.com/tracing/setup/dotnet/?tab=netframeworkonwindows) for the .NET Framework on windows cells. To start instrumenting your app:
+The buildpack also includes the [.NET Tracer](https://docs.datadoghq.com/tracing/setup/dotnet-core/??tab=windows#installation) for .NET on windows and linux cells. For linux, the debian .NET tracer is bundled when `DD_DOTNET_TRACING: true` is set.
+
+To start instrumenting your app:
 
 1. Register the directory containing the DLLs in your app.
 To do so, add the path `C:\Users\vcap\app\datadog\dotNetTracer` in the [`probing`](https://docs.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/runtime/probing-element) element in your `web.config` file.
@@ -101,9 +103,25 @@ To do so, add the path `C:\Users\vcap\app\datadog\dotNetTracer` in the [`probing
 </runtime>
 ```
 
+2. Setup the appropriate environment variables for your application depending on the OS the app will run on.
+
 Alternatively, you can install the [Datadog.Trace.ClrProfiler.Managed Nuget package](https://www.nuget.org/packages/Datadog.Trace.ClrProfiler.Managed) in your app before pushing it to CloudFoundry.
 
-2. Set the following environment variables in your application:
+### Linux (.NET Core Apps)
+
+Set the following environment variables in your application:
+```
+# Set your API key to send traces to Datadog
+cf set-env $YOUR_APP_NAME DD_API_KEY $YOUR_DATADOG_API_KEY
+# Setting this environment variable will bundle the .NET Tracing dependencies and enable the
+cf set-env $YOUR_APP_NAME DD_DOTNET_TRACING true
+# environment variables needed to automatically instrument your .NET Application
+cf restage $YOUR_APP_NAME
+```
+
+### Windows (.NET Framework Apps)
+
+Set the following environment variables in your application:
 ```
 # Set your API key to send traces to Datadog
 cf set-env $YOUR_APP_NAME DD_API_KEY $YOUR_DATADOG_API_KEY

--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ cf restage $YOUR_APP_NAME
 
 #### Log Collection
 
-Log collection is currently only available on Linux based applications.
-
 **Enable log collection**:
 
 To start collecting logs from your application in CloudFoundry, the Agent contained in the buildpack needs to be activated and log collection enabled.
@@ -59,6 +57,19 @@ The following parameters can be used to configure log collection:
 
 - `STD_LOG_COLLECTION_PORT`: Must be used when collecting logs from `stdout`/`stderr`. It redirects the `stdout`/`stderr` stream to the corresponding local port value.
 - `LOGS_CONFIG`: Use this option to configure the agent to listen to a local TCP port and set the value for the `service` and `source` parameters.
+
+**Additional steps for windows**
+
+To get logs from your .NET Framework applications running on windows cells, follow these additional steps:
+1. Create a `Procfile` (see https://docs.cloudfoundry.org/buildpacks/prod-server.html#procfile) at the root of your app containing the following line:
+    ```
+    web: run.cmd
+    ```
+2. Create a file named `run.cmd` at the root of your application. This file contains the command to startup your application
+    ```batch
+    .cloudfoundry\hwc.exe 2>&1 | powershell C:\Users\vcap\app\datadog\scripts\redirect_logs.ps1
+    ```
+    This command starts the usual `hwc` buildpack, and redirects its output to a script that forwards it to the agent, so that your app logs appear in Datadog.
 
 **Example**:
 

--- a/README.md
+++ b/README.md
@@ -58,10 +58,10 @@ The following parameters can be used to configure log collection:
 - `STD_LOG_COLLECTION_PORT`: Must be used when collecting logs from `stdout`/`stderr`. It redirects the `stdout`/`stderr` stream to the corresponding local port value.
 - `LOGS_CONFIG`: Use this option to configure the agent to listen to a local TCP port and set the value for the `service` and `source` parameters.
 
-**Additional steps for windows**
+**Additional steps for Windows**
 
-To get logs from your .NET Framework applications running on windows cells, follow these additional steps:
-1. Create a `Procfile` (see https://docs.cloudfoundry.org/buildpacks/prod-server.html#procfile) at the root of your app containing the following line:
+To get logs from your .NET Framework applications running on Windows cells, follow these additional steps:
+1. Create a `Procfile` (see the [About Procfiles CloudFoundry documentation](https://docs.cloudfoundry.org/buildpacks/prod-server.html#procfile)) at the root of your application containing the following line:
     ```
     web: run.cmd
     ```
@@ -69,7 +69,7 @@ To get logs from your .NET Framework applications running on windows cells, foll
     ```batch
     .cloudfoundry\hwc.exe 2>&1 | powershell C:\Users\vcap\app\datadog\scripts\redirect_logs.ps1
     ```
-    This command starts the usual `hwc` buildpack, and redirects its output to a script that forwards it to the agent, so that your app logs appear in Datadog.
+    This command starts the usual `hwc` buildpack, and redirects its output to a script that forwards it to the Agent, so that your application logs appear in Datadog.
 
 **Example**:
 
@@ -87,14 +87,14 @@ All the options supported by the Agent in the main configuration file (`lib/dist
 
 #### .NET Traces
 
-The buildpack also includes the [.NET Tracer](https://docs.datadoghq.com/tracing/setup/dotnet-core/??tab=windows#installation) for .NET on windows and linux cells. For linux, the debian .NET tracer is bundled when `DD_DOTNET_TRACING: true` is set.
+The buildpack also includes the [.NET Tracer](https://docs.datadoghq.com/tracing/setup/dotnet-core/?tab=windows#installation) for .NET on Windows and linux cells. For linux, the Debian .NET tracer is bundled when `DD_DOTNET_TRACING: true` is set.
 
-To start instrumenting your app:
+To start instrumenting your application:
 
-1. Register the directory containing the DLLs in your app.
-To do so, add the path `C:\Users\vcap\app\datadog\dotNetTracer` in the [`probing`](https://docs.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/runtime/probing-element) element in your `web.config` file.
+1. Register the directory containing the DLLs in your application by adding the path `C:\Users\vcap\app\datadog\dotNetTracer` in the [`probing`](https://docs.microsoft.com/en-us/dotnet/framework/configure-apps/file-schema/runtime/probing-element) element in your `web.config` file.
 
 **example**:
+
 ```xml
 <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
@@ -103,9 +103,10 @@ To do so, add the path `C:\Users\vcap\app\datadog\dotNetTracer` in the [`probing
 </runtime>
 ```
 
-2. Setup the appropriate environment variables for your application depending on the OS the app will run on. These can be set directly in the `run.cmd` file.
+2. In the `run.cmd` file, setup the appropriate environment variables for your application depending on the OS the application is running on.
 
 **example**:
+
 ```
 # Setup the Tracing Environment Variables
 SET COR_ENABLE_PROFILING=1
@@ -119,7 +120,7 @@ SET DD_TRACE_LOG_PATH=\Users\vcap\app\datadog\dotNetTracer\dotnet-profiler.log
 .cloudfoundry\hwc.exe | powershell C:\Users\vcap\app\datadog\scripts\redirect_logs.ps1 2>&1
 ```
 
-Alternatively, you can install the [Datadog.Trace.ClrProfiler.Managed Nuget package](https://www.nuget.org/packages/Datadog.Trace.ClrProfiler.Managed) in your app before pushing it to CloudFoundry.
+Alternatively, you can install the [Datadog.Trace.ClrProfiler.Managed Nuget package](https://www.nuget.org/packages/Datadog.Trace.ClrProfiler.Managed) in your application before pushing it to CloudFoundry.
 
 ### Linux (.NET Core Apps)
 
@@ -134,9 +135,10 @@ cf restage $YOUR_APP_NAME
 ```
 
 ### DogStatsD Away!
-You're all set up to use DogStatsD. Import the relevant library and start sending data! To learn more, [check our our documentation](https://docs.datadoghq.com/guides/DogStatsD/). Additionally, there is [a list of DogStatsD libraries](https://docs.datadoghq.com/libraries/) you can check out to find one that's compatible with your application.
 
-Note: On Windows .NET applications you can add the Dogstatsd-CSharp client to your project's dependencies to submit custom metrics from your application. This requires publishing the application (to include the dogstatsd client dependency) and passing the published folder in your app manifest.
+You're all set up to use DogStatsD. Import the relevant library and start sending data! To learn more, [check the Datadog DogStastD documentation](https://docs.datadoghq.com/guides/DogStatsD/). Additionally, there is [a list of DogStatsD libraries](https://docs.datadoghq.com/libraries/) you can check out to find one that's compatible with your application.
+
+**Note**: On Windows .NET applications you can add the [Dogstatsd-CSharp client](https://github.com/DataDog/dogstatsd-csharp-client) to your project's dependencies to submit custom metrics from your application. This requires publishing the application (to include the DogStatsD client dependency) and passing the published folder in your application manifest.
 
 ## Docker
 

--- a/bin/compile
+++ b/bin/compile
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# This file is a deprecated alternative to bin/supply (same content) and is here to maintain backwards compatibility for older PAS versions
+# https://docs.pivotal.io/pivotalcf/2-6/buildpacks/understand-buildpacks.html
+
 echo "-----> DatadogBuildpack/compile"
 
 BIN_DIR=$(cd $(dirname $0); pwd)

--- a/bin/supply
+++ b/bin/supply
@@ -38,3 +38,9 @@ chmod +x $BUILD_DIR/datadog/trace-agent
 chmod +x $BUILD_DIR/.profile.d/00-test-endpoint.sh
 chmod +x $BUILD_DIR/.profile.d/01-redirect-logs.sh
 chmod +x $BUILD_DIR/.profile.d/02-run-datadog.sh
+
+# Only add the dotnet tracer if DD_DOTNET_TRACING is enabled
+if [ "$DD_DOTNET_TRACING" == 'true' ]; then
+  mkdir -p $BUILD_DIR/datadog/dotnet
+  dpkg --extract $ROOT_DIR/lib/dotnet-tracer.deb $BUILD_DIR/datadog/dotnet/
+fi

--- a/bin/supply.bat
+++ b/bin/supply.bat
@@ -1,0 +1,1 @@
+powershell.exe %~dp0\supply.ps1 %~f1 %~f2 %~f3

--- a/bin/supply.ps1
+++ b/bin/supply.ps1
@@ -1,0 +1,25 @@
+echo "-----> DatadogBuildpack/supply"
+
+$BIN_DIR=Split-Path -Path $PSCOMMANDPATH
+$ROOT_DIR=Split-Path -Path $BIN_DIR
+$BUILD_DIR=$ARGS[0]
+
+echo "       Extracting Datadog Agent"
+
+New-Item -Path "$BUILD_DIR\datadog\scripts" -ItemType Directory
+New-Item -Path "$BUILD_DIR\.profile.d" -ItemType Directory
+New-Item -Path "$BUILD_DIR\datadog\AppData" -ItemType Directory
+
+# Extract agent
+Expand-Archive -LiteralPath $ROOT_DIR\lib\agent-binaries.zip -DestinationPath $BUILD_DIR\datadog
+Get-ChildItem -Path "$BUILD_DIR\datadog\etc" -Recurse | Move-Item -Destination "$BUILD_DIR\datadog\AppData"
+
+# Extract .NET tracer
+Start-Process "MSIEXEC" -ArgumentList "/a $ROOT_DIR\lib\dotnet-tracer.msi /qn TARGETDIR=$BUILD_DIR\datadog\extracted-dotnet-tracer" -Wait -NoNewWindow
+Move-Item -Path "$BUILD_DIR\datadog\extracted-dotnet-tracer\Datadog\.NET Tracer" -Destination "$BUILD_DIR\datadog\dotNetTracer"
+Remove-Item -Force -Recurse -Path "$BUILD_DIR\datadog\extracted-dotnet-tracer"
+
+Copy-Item -Path "$ROOT_DIR\lib\scripts\windows\get_tags.ps1" -Destination "$BUILD_DIR\datadog\scripts\get_tags.ps1"
+Copy-Item -Path "$ROOT_DIR\lib\scripts\windows\run-datadog.ps1" -Destination "$BUILD_DIR\datadog\scripts\run-datadog.ps1"
+Copy-Item -Path "$ROOT_DIR\lib\scripts\windows\run-datadog.bat" -Destination "$BUILD_DIR\.profile.d\01-run-datadog.bat"
+Copy-Item -Path "$ROOT_DIR\lib\scripts\windows\datadog-agent.bat" -Destination "$BUILD_DIR\datadog\datadog-agent.bat"

--- a/bin/supply.ps1
+++ b/bin/supply.ps1
@@ -15,9 +15,7 @@ Expand-Archive -LiteralPath $ROOT_DIR\lib\agent-binaries.zip -DestinationPath $B
 Get-ChildItem -Path "$BUILD_DIR\datadog\etc" -Recurse | Move-Item -Destination "$BUILD_DIR\datadog\AppData"
 
 # Extract .NET tracer
-Start-Process "MSIEXEC" -ArgumentList "/a $ROOT_DIR\lib\dotnet-tracer.msi /qn TARGETDIR=$BUILD_DIR\datadog\extracted-dotnet-tracer" -Wait -NoNewWindow
-Move-Item -Path "$BUILD_DIR\datadog\extracted-dotnet-tracer\Datadog\.NET Tracer" -Destination "$BUILD_DIR\datadog\dotNetTracer"
-Remove-Item -Force -Recurse -Path "$BUILD_DIR\datadog\extracted-dotnet-tracer"
+Expand-Archive -LiteralPath "$ROOT_DIR\lib\dotnet-tracer.zip" -DestinationPath "$BUILD_DIR\datadog\dotNetTracer"
 
 Copy-Item -Path "$ROOT_DIR\lib\scripts\windows\get_tags.ps1" -Destination "$BUILD_DIR\datadog\scripts\get_tags.ps1"
 Copy-Item -Path "$ROOT_DIR\lib\scripts\windows\redirect_logs.ps1" -Destination "$BUILD_DIR\datadog\scripts\redirect_logs.ps1"

--- a/bin/supply.ps1
+++ b/bin/supply.ps1
@@ -20,6 +20,7 @@ Move-Item -Path "$BUILD_DIR\datadog\extracted-dotnet-tracer\Datadog\.NET Tracer"
 Remove-Item -Force -Recurse -Path "$BUILD_DIR\datadog\extracted-dotnet-tracer"
 
 Copy-Item -Path "$ROOT_DIR\lib\scripts\windows\get_tags.ps1" -Destination "$BUILD_DIR\datadog\scripts\get_tags.ps1"
+Copy-Item -Path "$ROOT_DIR\lib\scripts\windows\redirect_logs.ps1" -Destination "$BUILD_DIR\datadog\scripts\redirect_logs.ps1"
 Copy-Item -Path "$ROOT_DIR\lib\scripts\windows\run-datadog.ps1" -Destination "$BUILD_DIR\datadog\scripts\run-datadog.ps1"
 Copy-Item -Path "$ROOT_DIR\lib\scripts\windows\run-datadog.bat" -Destination "$BUILD_DIR\.profile.d\01-run-datadog.bat"
 Copy-Item -Path "$ROOT_DIR\lib\scripts\windows\datadog-agent.bat" -Destination "$BUILD_DIR\datadog\datadog-agent.bat"

--- a/build
+++ b/build
@@ -62,6 +62,7 @@ function main() {
     rm -f $SRCDIR/lib/dogstatsd
     rm -f $SRCDIR/lib/trace-agent
     # rm -f $SRCDIR/lib/agent-binaries.zip
+    rm -f $SRCDIR/lib/dotnet-tracer.msi
 
     if [ -n "$VERSION" ]; then
       PUPPY_DOWNLOAD_URL="$PUPPY_DOWNLOAD_URL/agent-$VERSION"
@@ -78,6 +79,8 @@ function main() {
     chmod +x $SRCDIR/lib/dogstatsd
 
     # curl $AGENT_BINARIES_DOWNLOAD_URL -o ./lib/agent-binaries.zip
+
+    curl -L $AGENT_DOTNET_TRACER_DOWNLOAD_URL -o ./lib/dotnet-tracer.msi
 
     # Does not support versioning for now, keep it dumb until trace-agent merge with the Agent6
     # curl -L $TRACEAGENT_DOWNLOAD_URL -o ./lib/trace-agent

--- a/build
+++ b/build
@@ -7,12 +7,22 @@ PUPPY_DOWNLOAD_URL="https://s3.amazonaws.com/dd-agent/agent7/puppy/linux"
 DOGSTATSD_DOWNLOAD_URL="https://s3.amazonaws.com/dd-agent/dsd7/dogstatsd/linux"
 TRACEAGENT_DOWNLOAD_URL_HEAD="https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/datadog-agent_"
 TRACEAGENT_DOWNLOAD_URL_TAIL="-1_amd64.deb"
-TRACE_DEFAULT_VERSION="7.17.0"
+
+AGENT_DEFAULT_VERSION="7.17.0"
+DOTNET_TRACER_DEFAULT_VERSION="1.6.0"
+
+AGENT_VERSION=${AGENT_VERSION:-$AGENT_DEFAULT_VERSION}
+DOTNET_TRACER_VERSION=${DOTNET_TRACER_VERSION:-$DOTNET_TRACER_DEFAULT_VERSION}
+AGENT_DEB_DOWNLOAD_URL="https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/datadog-agent_${AGENT_VERSION}-1_amd64.deb"
+# [TODO] Update this to the zip location and uncomment the commented lines in this script
+# AGENT_BINARIES_DOWNLOAD_URL="https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-${AGENT_VERSION}.msi"
+AGENT_DOTNET_TRACER_DOWNLOAD_URL="https://github.com/DataDog/dd-trace-dotnet/releases/download/v${DOTNET_TRACER_VERSION}/datadog-dotnet-apm-${DOTNET_TRACER_VERSION}-x64.msi"
+
 
 TMPDIR="$SRCDIR/tmp"
 
 function download_trace_agent() {
-  local trace_version="${1:-$TRACE_DEFAULT_VERSION}"
+  local trace_version="${1:-$AGENT_VERSION}"
   local trace_agent_download_url="$TRACEAGENT_DOWNLOAD_URL_HEAD$trace_version$TRACEAGENT_DOWNLOAD_URL_TAIL"
 
   local archiver="tar"
@@ -51,6 +61,7 @@ function main() {
     rm -f $SRCDIR/lib/puppy
     rm -f $SRCDIR/lib/dogstatsd
     rm -f $SRCDIR/lib/trace-agent
+    # rm -f $SRCDIR/lib/agent-binaries.zip
 
     if [ -n "$VERSION" ]; then
       PUPPY_DOWNLOAD_URL="$PUPPY_DOWNLOAD_URL/agent-$VERSION"
@@ -65,6 +76,8 @@ function main() {
 
     curl $DOGSTATSD_DOWNLOAD_URL -o ./lib/dogstatsd
     chmod +x $SRCDIR/lib/dogstatsd
+
+    # curl $AGENT_BINARIES_DOWNLOAD_URL -o ./lib/agent-binaries.zip
 
     # Does not support versioning for now, keep it dumb until trace-agent merge with the Agent6
     # curl -L $TRACEAGENT_DOWNLOAD_URL -o ./lib/trace-agent

--- a/build
+++ b/build
@@ -9,15 +9,15 @@ TRACEAGENT_DOWNLOAD_URL_HEAD="https://s3.amazonaws.com/apt.datadoghq.com/pool/d/
 TRACEAGENT_DOWNLOAD_URL_TAIL="-1_amd64.deb"
 
 AGENT_DEFAULT_VERSION="7.17.0"
-DOTNET_TRACER_DEFAULT_VERSION="1.6.0"
+DOTNET_TRACER_DEFAULT_VERSION="1.13.2"
 
 AGENT_VERSION=${AGENT_VERSION:-$AGENT_DEFAULT_VERSION}
 DOTNET_TRACER_VERSION=${DOTNET_TRACER_VERSION:-$DOTNET_TRACER_DEFAULT_VERSION}
 AGENT_DEB_DOWNLOAD_URL="https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/datadog-agent_${AGENT_VERSION}-1_amd64.deb"
 # [TODO] Update this to the zip location and uncomment the commented lines in this script
 # AGENT_BINARIES_DOWNLOAD_URL="https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-${AGENT_VERSION}.msi"
-AGENT_DOTNET_TRACER_DOWNLOAD_URL="https://github.com/DataDog/dd-trace-dotnet/releases/download/v${DOTNET_TRACER_VERSION}/datadog-dotnet-apm-${DOTNET_TRACER_VERSION}-x64.msi"
-
+AGENT_DOTNET_TRACER_WIN_DOWNLOAD_URL="https://github.com/DataDog/dd-trace-dotnet/releases/download/v${DOTNET_TRACER_VERSION}/datadog-dotnet-apm-${DOTNET_TRACER_VERSION}-x64.msi"
+AGENT_DOTNET_TRACER_DEB_DOWNLOAD_URL="https://github.com/DataDog/dd-trace-dotnet/releases/download/v${DOTNET_TRACER_VERSION}/datadog-dotnet-apm_${DOTNET_TRACER_VERSION}_amd64.deb"
 
 TMPDIR="$SRCDIR/tmp"
 
@@ -63,6 +63,7 @@ function main() {
     rm -f $SRCDIR/lib/trace-agent
     # rm -f $SRCDIR/lib/agent-binaries.zip
     rm -f $SRCDIR/lib/dotnet-tracer.msi
+    rm -f $SRCDIR/lib/dotnet-tracer.deb
 
     if [ -n "$VERSION" ]; then
       PUPPY_DOWNLOAD_URL="$PUPPY_DOWNLOAD_URL/agent-$VERSION"
@@ -80,8 +81,8 @@ function main() {
 
     # curl $AGENT_BINARIES_DOWNLOAD_URL -o ./lib/agent-binaries.zip
 
-    curl -L $AGENT_DOTNET_TRACER_DOWNLOAD_URL -o ./lib/dotnet-tracer.msi
-
+    curl -L $AGENT_DOTNET_TRACER_WIN_DOWNLOAD_URL -o ./lib/dotnet-tracer.msi
+    curl -L $AGENT_DOTNET_TRACER_DEB_DOWNLOAD_URL -o ./lib/dotnet-tracer.deb
     # Does not support versioning for now, keep it dumb until trace-agent merge with the Agent6
     # curl -L $TRACEAGENT_DOWNLOAD_URL -o ./lib/trace-agent
     download_trace_agent $VERSION

--- a/build
+++ b/build
@@ -7,7 +7,7 @@ PUPPY_DOWNLOAD_URL="https://s3.amazonaws.com/dd-agent/agent7/puppy/linux"
 DOGSTATSD_DOWNLOAD_URL="https://s3.amazonaws.com/dd-agent/dsd7/dogstatsd/linux"
 TRACEAGENT_DOWNLOAD_URL_HEAD="https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/datadog-agent_"
 TRACEAGENT_DOWNLOAD_URL_TAIL="-1_amd64.deb"
-TRACE_DEFAULT_VERSION="7.16.0"
+TRACE_DEFAULT_VERSION="7.17.0"
 
 TMPDIR="$SRCDIR/tmp"
 

--- a/build
+++ b/build
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 SRCDIR=$(cd "$(dirname $0)/." && pwd)
 NAME="datadog-cloudfoundry-buildpack"
@@ -8,15 +9,14 @@ DOGSTATSD_DOWNLOAD_URL="https://s3.amazonaws.com/dd-agent/dsd7/dogstatsd/linux"
 TRACEAGENT_DOWNLOAD_URL_HEAD="https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/datadog-agent_"
 TRACEAGENT_DOWNLOAD_URL_TAIL="-1_amd64.deb"
 
-AGENT_DEFAULT_VERSION="7.17.0"
-DOTNET_TRACER_DEFAULT_VERSION="1.13.2"
+AGENT_DEFAULT_VERSION="7.18.1"
+DOTNET_TRACER_DEFAULT_VERSION="1.16.0"
 
 AGENT_VERSION=${AGENT_VERSION:-$AGENT_DEFAULT_VERSION}
 DOTNET_TRACER_VERSION=${DOTNET_TRACER_VERSION:-$DOTNET_TRACER_DEFAULT_VERSION}
 AGENT_DEB_DOWNLOAD_URL="https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/datadog-agent_${AGENT_VERSION}-1_amd64.deb"
-# [TODO] Update this to the zip location and uncomment the commented lines in this script
-# AGENT_BINARIES_DOWNLOAD_URL="https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-${AGENT_VERSION}.msi"
-AGENT_DOTNET_TRACER_WIN_DOWNLOAD_URL="https://github.com/DataDog/dd-trace-dotnet/releases/download/v${DOTNET_TRACER_VERSION}/datadog-dotnet-apm-${DOTNET_TRACER_VERSION}-x64.msi"
+AGENT_BINARIES_DOWNLOAD_URL="https://s3.amazonaws.com/dd-agent/agent7/cf-buildpack/windows/agent-binaries-${AGENT_VERSION}-1-x86_64.zip"
+AGENT_DOTNET_TRACER_WIN_DOWNLOAD_URL="https://github.com/DataDog/dd-trace-dotnet/releases/download/v${DOTNET_TRACER_VERSION}/windows-tracer-home.zip"
 AGENT_DOTNET_TRACER_DEB_DOWNLOAD_URL="https://github.com/DataDog/dd-trace-dotnet/releases/download/v${DOTNET_TRACER_VERSION}/datadog-dotnet-apm_${DOTNET_TRACER_VERSION}_amd64.deb"
 
 TMPDIR="$SRCDIR/tmp"
@@ -37,7 +37,7 @@ function download_trace_agent() {
   fi
 
   mkdir -p $TMPDIR
-  curl -L $trace_agent_download_url -o ./tmp/datadog-agent.deb
+  curl --fail -L $trace_agent_download_url -o ./tmp/datadog-agent.deb
   pushd $TMPDIR
     ar x datadog-agent.deb
     $archiver -xzf data.tar.gz
@@ -61,8 +61,8 @@ function main() {
     rm -f $SRCDIR/lib/puppy
     rm -f $SRCDIR/lib/dogstatsd
     rm -f $SRCDIR/lib/trace-agent
-    # rm -f $SRCDIR/lib/agent-binaries.zip
-    rm -f $SRCDIR/lib/dotnet-tracer.msi
+    rm -f $SRCDIR/lib/agent-binaries.zip
+    rm -f $SRCDIR/lib/dotnet-tracer.zip
     rm -f $SRCDIR/lib/dotnet-tracer.deb
 
     if [ -n "$VERSION" ]; then
@@ -73,16 +73,16 @@ function main() {
       DOGSTATSD_DOWNLOAD_URL="$DOGSTATSD_DOWNLOAD_URL/dogstatsd-latest"
     fi
 
-    curl $PUPPY_DOWNLOAD_URL -o $SRCDIR/lib/puppy
+    curl --fail $PUPPY_DOWNLOAD_URL -o $SRCDIR/lib/puppy
     chmod +x $SRCDIR/lib/puppy
 
-    curl $DOGSTATSD_DOWNLOAD_URL -o ./lib/dogstatsd
+    curl --fail $DOGSTATSD_DOWNLOAD_URL -o ./lib/dogstatsd
     chmod +x $SRCDIR/lib/dogstatsd
 
-    # curl $AGENT_BINARIES_DOWNLOAD_URL -o ./lib/agent-binaries.zip
+    curl --fail $AGENT_BINARIES_DOWNLOAD_URL -o ./lib/agent-binaries.zip
 
-    curl -L $AGENT_DOTNET_TRACER_WIN_DOWNLOAD_URL -o ./lib/dotnet-tracer.msi
-    curl -L $AGENT_DOTNET_TRACER_DEB_DOWNLOAD_URL -o ./lib/dotnet-tracer.deb
+    curl --fail -L $AGENT_DOTNET_TRACER_WIN_DOWNLOAD_URL -o ./lib/dotnet-tracer.zip
+    curl --fail -L $AGENT_DOTNET_TRACER_DEB_DOWNLOAD_URL -o ./lib/dotnet-tracer.deb
     # Does not support versioning for now, keep it dumb until trace-agent merge with the Agent6
     # curl -L $TRACEAGENT_DOWNLOAD_URL -o ./lib/trace-agent
     download_trace_agent $VERSION

--- a/build
+++ b/build
@@ -33,8 +33,6 @@ function download_trace_agent() {
     $archiver -xzf data.tar.gz
   popd
   cp $TMPDIR/opt/datadog-agent/embedded/bin/trace-agent $SRCDIR/lib/trace-agent
-  # Download the template files that are required for the status command
-  cp -r $TMPDIR/opt/datadog-agent/bin/agent/dist/templates/ $SRCDIR/lib/dist/templates
   rm -rf $TMPDIR/*
 }
 

--- a/lib/run-datadog.sh
+++ b/lib/run-datadog.sh
@@ -18,6 +18,17 @@ start_datadog() {
     export LOGS_CONFIG_DIR=$DATADOG_DIR/dist/conf.d/logs.d
     export LOGS_CONFIG
 
+    # Setup .NET Tracing configuration if DD_DOTNET_TRACING is set to true
+    if [ "$DD_DOTNET_TRACING" = "true" ]; then
+      export DD_TRACE_ENABLED=true
+      export CORECLR_ENABLE_PROFILING=1
+      export CORECLR_PROFILER="{846F5F1C-F9AE-4B07-969E-05C26BC060D8}"
+      export CORECLR_PROFILER_PATH=$DATADOG_DIR/dotnet/opt/datadog/Datadog.Trace.ClrProfiler.Native.so
+      export DD_INTEGRATIONS=$DATADOG_DIR/dotnet/opt/datadog/integrations.json
+      export DD_DOTNET_TRACER_HOME=$DATADOG_DIR/dotnet/opt/datadog/
+      export DD_TRACE_LOG_PATH=$DATADOG_DIR/dotnet/dotnet.log
+    fi
+
     # create and configure set /conf.d if integrations are enabled
     if [ "$DD_ENABLE_CHECKS" = "true" ] || [ -n "$LOGS_CONFIG" ] ; then
       mkdir $DATADOG_DIR/dist/conf.d

--- a/lib/scripts/windows/datadog-agent.bat
+++ b/lib/scripts/windows/datadog-agent.bat
@@ -1,0 +1,1 @@
+\Users\vcap\app\datadog\bin\agent.exe -c \Users\vcap\app\datadog\AppData\datadog.yaml %*

--- a/lib/scripts/windows/get_tags.ps1
+++ b/lib/scripts/windows/get_tags.ps1
@@ -1,10 +1,12 @@
 $vcapApp = $env:VCAP_APPLICATION
 $vcapApp = $vcapApp | ConvertFrom-JSON
 
+# Collect host tags about the application
 $vcap_variables = "application_id", "name", "instance_index", "space_name"
 
 $tags = @()
 
+# Documentation for the VCAP_APPLICATION env var - https://docs.run.pivotal.io/devguide/deploy-apps/environment-variable.html#VCAP-APPLICATION
 foreach ($element in $vcap_variables) {
     $vcap_var = $vcapApp.$element
     If ($vcap_var -ne $null) {
@@ -23,7 +25,7 @@ If ($vcap_var -ne $null) {
     }
 }
 
-# Require user tags on windows to be a list of tags @()
+# Require user tags on windows to be a list of tags, i.e. $TAGS=@(env:staging, app:web)
 $user_tags = $env:TAGS
 If ($user_tags -ne $null) {
     foreach ($element in $user_tags) {
@@ -31,6 +33,7 @@ If ($user_tags -ne $null) {
     }
 }
 
+# Support the same for the DD_TAGS environment variable
 $user_tags = $env:DD_TAGS
 If ($user_tags -ne $null) {
     foreach ($element in $user_tags) {

--- a/lib/scripts/windows/get_tags.ps1
+++ b/lib/scripts/windows/get_tags.ps1
@@ -1,0 +1,42 @@
+$vcapApp = $env:VCAP_APPLICATION
+$vcapApp = $vcapApp | ConvertFrom-JSON
+
+$vcap_variables = "application_id", "name", "instance_index", "space_name"
+
+$tags = @()
+
+foreach ($element in $vcap_variables) {
+    $vcap_var = $vcapApp.$element
+    If ($vcap_var -ne $null) {
+        $key = $element
+        If($key -eq "name") {
+            $key = "application_name"
+        }
+        $tags += "${key}:${vcap_var}"
+    }
+}
+
+$uris = $vcapApp.uris
+If ($vcap_var -ne $null) {
+    foreach ($element in $uris) {
+        $tags += "uri:${element}"
+    }
+}
+
+# Require user tags on windows to be a list of tags @()
+$user_tags = $env:TAGS
+If ($user_tags -ne $null) {
+    foreach ($element in $user_tags) {
+        $tags += $element
+    }
+}
+
+$user_tags = $env:DD_TAGS
+If ($user_tags -ne $null) {
+    foreach ($element in $user_tags) {
+        $tags += $element
+    }
+}
+
+# Print tags
+return $tags

--- a/lib/scripts/windows/get_tags.ps1
+++ b/lib/scripts/windows/get_tags.ps1
@@ -1,3 +1,5 @@
+# This script retrieves some expected tags from various CF provided environment variables
+# as well as some custom tags provided by the user.
 $vcapApp = $env:VCAP_APPLICATION
 $vcapApp = $vcapApp | ConvertFrom-JSON
 
@@ -7,6 +9,7 @@ $vcap_variables = "application_id", "name", "instance_index", "space_name"
 $tags = @()
 
 # Documentation for the VCAP_APPLICATION env var - https://docs.run.pivotal.io/devguide/deploy-apps/environment-variable.html#VCAP-APPLICATION
+# Pull out expected key/values to use as tags.
 foreach ($element in $vcap_variables) {
     $vcap_var = $vcapApp.$element
     If ($vcap_var -ne $null) {

--- a/lib/scripts/windows/redirect_logs.ps1
+++ b/lib/scripts/windows/redirect_logs.ps1
@@ -1,0 +1,44 @@
+$hostname = "localhost"
+$port = $Env:STD_LOG_COLLECTION_PORT # 10514
+
+# Recreate the socket, writer objects in the case that the connection was closed
+# https://docs.microsoft.com/en-us/dotnet/api/system.net.sockets.tcpclient?view=netframework-4.8
+function Recreate-Socket {
+    Write-Host "Connecting to $hostname $port"
+    try {
+        $Socket = New-Object System.Net.Sockets.TCPClient($hostname,$port)
+        $Stream = $Socket.GetStream()
+        $Writer = New-Object System.IO.StreamWriter($Stream)
+        $Writer.AutoFlush = $true;
+        return $Socket, $Writer
+    } catch {
+        Write-Host "Couldn't connect to $hostname $port"
+    }
+}
+
+function Run {
+    $Socket, $Writer = Recreate-Socket
+    while($true)
+    {
+        # Reconnect if the socket is disconnected
+        # (The Datadog Agent times out the connection if it does not receive
+        # logs during 1 minute)
+        If ($Socket.Connected -eq $false) {
+            $Socket.Close()
+            $Socket, $Writer = Recreate-Socket
+        }
+        $line = read-host
+        $Writer.WriteLine($line)
+        Write-Host $line
+    }
+}
+
+# Ensure that the user chooses to collect logs and the proper variables are set
+If ($Env:DD_LOGS_ENABLED -eq $true) {
+    if (!(Test-Path 'env:LOGS_CONFIG') -Or !(Test-Path 'env:STD_LOG_COLLECTION_PORT')) {
+        Write-Host "Can't collect logs; LOGS_CONFIG and/or STD_LOG_COLLECTION_PORT is not set"
+    } else {
+        Write-Host "Collecing logs for config: $LOGS_CONFIG"
+        Run
+    }
+}

--- a/lib/scripts/windows/run-datadog.bat
+++ b/lib/scripts/windows/run-datadog.bat
@@ -1,0 +1,2 @@
+echo "Starting Datadog Agent"
+powershell "C:\Users\vcap\app\datadog\scripts\run-datadog.ps1"

--- a/lib/scripts/windows/run-datadog.ps1
+++ b/lib/scripts/windows/run-datadog.ps1
@@ -14,6 +14,11 @@ echo "$tags_out" | Out-File "$DATADOG_DIR\AppData\datadog.yaml" -Append -Encodin
 # Update the path to the check configuration files
 echo "confd_path: $DATADOG_DIR\AppData\datadog-agent\conf.d" | Out-File "$DATADOG_DIR\AppData\datadog.yaml" -Append -Encoding "UTF8"
 
+# Remove the core checks if DD_ENABLE_CHECKS is false
+If ("$DD_ENABLE_CHECKS" -ne $true) {
+    Remove-Item -Path "$DATADOG_DIR\AppData\datadog-agent\conf.d\*" -Recurse
+}
+
 # Write the config for the logs
 $LOGS_CONFIG_DIR="$DATADOG_DIR\AppData\datadog-agent\conf.d\logs.d"
 New-Item $LOGS_CONFIG_DIR -ItemType "directory" -Force

--- a/lib/scripts/windows/run-datadog.ps1
+++ b/lib/scripts/windows/run-datadog.ps1
@@ -1,0 +1,24 @@
+# Fix datadog.yaml for apm log file since it cannot be set via env vars currently
+$DATADOG_DIR="C:\Users\vcap\app\datadog"
+echo "apm_config:" | Out-File "$DATADOG_DIR\AppData\datadog.yaml" -Append -Encoding "UTF8"
+echo "  log_file: $DATADOG_DIR\trace.log" | Out-File "$DATADOG_DIR\AppData\datadog.yaml" -Append -Encoding "UTF8"
+
+# Write the DD tags we detect out to the datadog.yaml file
+$tags = & "$DATADOG_DIR\scripts\get_tags.ps1"
+$tags_out = "tags:`n"
+foreach ($element in $tags) {
+    $tags_out += "    - $element`n"
+}
+echo "$tags_out" | Out-File "$DATADOG_DIR\AppData\datadog.yaml" -Append -Encoding "UTF8"
+
+# Update the path to the check configuration files
+echo "confd_path: $DATADOG_DIR\AppData\datadog-agent\conf.d" | Out-File "$DATADOG_DIR\AppData\datadog.yaml" -Append -Encoding "UTF8"
+
+$Env:LOGS_CONFIG_DIR="$DATADOG_DIR\AppData\conf.d\logs.d"
+New-Item $Env:LOGS_CONFIG_DIR -ItemType "directory" -Force
+
+# Logs, core checks, and dogstatsd
+Start-Process "$DATADOG_DIR\bin\agent.exe" -ArgumentList "run -c $DATADOG_DIR\AppData" -NoNewWindow
+
+# Traces
+Start-Process "$DATADOG_DIR\bin\agent\trace-agent.exe" -ArgumentList "--config $DATADOG_DIR\AppData\datadog.yaml" -NoNewWindow

--- a/lib/scripts/windows/run-datadog.ps1
+++ b/lib/scripts/windows/run-datadog.ps1
@@ -14,11 +14,16 @@ echo "$tags_out" | Out-File "$DATADOG_DIR\AppData\datadog.yaml" -Append -Encodin
 # Update the path to the check configuration files
 echo "confd_path: $DATADOG_DIR\AppData\datadog-agent\conf.d" | Out-File "$DATADOG_DIR\AppData\datadog.yaml" -Append -Encoding "UTF8"
 
-$Env:LOGS_CONFIG_DIR="$DATADOG_DIR\AppData\conf.d\logs.d"
-New-Item $Env:LOGS_CONFIG_DIR -ItemType "directory" -Force
+# Write the config for the logs
+$LOGS_CONFIG_DIR="$DATADOG_DIR\AppData\datadog-agent\conf.d\logs.d"
+New-Item $LOGS_CONFIG_DIR -ItemType "directory" -Force
+echo "{`"logs`":$Env:LOGS_CONFIG}" | Out-File $LOGS_CONFIG_DIR\logs.yaml
 
 # Logs, core checks, and dogstatsd
 Start-Process "$DATADOG_DIR\bin\agent.exe" -ArgumentList "run -c $DATADOG_DIR\AppData" -NoNewWindow
+
+# Start redirecting logs to the agent port
+Start-Process "$DATADOG_DIR\scripts\redirect_logs.ps1"
 
 # Traces
 Start-Process "$DATADOG_DIR\bin\agent\trace-agent.exe" -ArgumentList "--config $DATADOG_DIR\AppData\datadog.yaml" -NoNewWindow

--- a/lib/scripts/windows/run-datadog.ps1
+++ b/lib/scripts/windows/run-datadog.ps1
@@ -14,8 +14,17 @@ echo "$tags_out" | Out-File "$DATADOG_DIR\AppData\datadog.yaml" -Append -Encodin
 # Update the path to the check configuration files
 echo "confd_path: $DATADOG_DIR\AppData\datadog-agent\conf.d" | Out-File "$DATADOG_DIR\AppData\datadog.yaml" -Append -Encoding "UTF8"
 
+# Remove the core checks that aren't available as Go checks
+# Currently: network, load, disk. These are only available as python checks
+# and can't be run via the puppy
+Remove-Item -Path "$DATADOG_DIR\AppData\datadog-agent\conf.d\disk.d" -Recurse
+Remove-Item -Path "$DATADOG_DIR\AppData\datadog-agent\conf.d\load.d" -Recurse
+Remove-Item -Path "$DATADOG_DIR\AppData\datadog-agent\conf.d\network.d" -Recurse
+
 # Remove the core checks if DD_ENABLE_CHECKS is false
-If ("$DD_ENABLE_CHECKS" -ne $true) {
+# This needs to happen before we setup the logs config file
+If ("$Env:DD_ENABLE_CHECKS" -ne $true  -and "$Env:DD_ENABLE_CHECKS" -ne "true" ) {
+    echo "Removing Checks config based on DD_ENABLED_CHECKS being set to: $Env:DD_ENABLED_CHECKS"
     Remove-Item -Path "$DATADOG_DIR\AppData\datadog-agent\conf.d\*" -Recurse
 }
 

--- a/lib/scripts/windows/run-datadog.ps1
+++ b/lib/scripts/windows/run-datadog.ps1
@@ -22,8 +22,5 @@ echo "{`"logs`":$Env:LOGS_CONFIG}" | Out-File $LOGS_CONFIG_DIR\logs.yaml
 # Logs, core checks, and dogstatsd
 Start-Process "$DATADOG_DIR\bin\agent.exe" -ArgumentList "run -c $DATADOG_DIR\AppData" -NoNewWindow
 
-# Start redirecting logs to the agent port
-Start-Process "$DATADOG_DIR\scripts\redirect_logs.ps1"
-
 # Traces
 Start-Process "$DATADOG_DIR\bin\agent\trace-agent.exe" -ArgumentList "--config $DATADOG_DIR\AppData\datadog.yaml" -NoNewWindow


### PR DESCRIPTION
### Requirements for Contributing to this repository

* Fill out the template below. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* The pull request must only fix one issue, or add one feature, at the time.

### What does this PR do?

Add support for windows cloudfoundry buildpack environments
Supersedes - #76 and #61 

* Adds a datadog.bat file to easily interact with the agent executable to run things like the status command without needing to point to the config file
* Adds the .NET tracer and documents the way to automatically trace .NET applications (These environment variables need to be set by the user and cannot be auto set by the buildpack. This is because windows environment variables seem to be per process, so setting them in the buildpack scripts won't be reflected in the application process)
* Enables system metrics by default (including running dogstatsd)
* Adds support for logs by having the user pipe the application through a redirect_logs.ps1 script that redirects stdout -> a port the logs agent listens on

(Uses the agent binaries instead of the full package)

* This also includes adding the .NET tracer debian package in the buildpack zip as part of build time. IF `DD_DOTNET_TRACING` is set to true, the buildpack will include the .NET tracer on the final container and setup the required environment variables for automatic instrumentation. 

### Description of the Change

Uses the new zip artifact and starts the process of running single binaries as opposed to the full Datadog Agent

### Additional Notes

Currently this starts the puppy agent and the trace agent.

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
