### PR TITLE
Fix instance_index missing if instance_index is 0

### DIFF
--- a/lib/scripts/get_tags.py
+++ b/lib/scripts/get_tags.py
@@ -17,7 +17,7 @@ tags = []
 
 for vcap_var_name in vcap_variables:
     vcap_var = vcap_application.get(vcap_var_name)
-    if vcap_var:
+    if vcap_var is not None:
         key = vcap_var_name
         if vcap_var_name == 'name':
             key = 'application_name'


### PR DESCRIPTION
Fixes #85 

This will allow '0' to be a valid vcap_var value

The current check `if vcap_var` evaluates to falsy if vcap_car is 0. Checking against None ensures that 0 is a valid value.
