### PR TITLE
Prevent buildpack from blocking application startup when verbose application starts

### DIFF
--- a/bin/supply
+++ b/bin/supply
@@ -25,8 +25,8 @@ cp $ROOT_DIR/lib/trace-agent $BUILD_DIR/datadog/trace-agent
 cp $ROOT_DIR/lib/scripts/get_tags.py $BUILD_DIR/datadog/scripts/get_tags.py
 cp $ROOT_DIR/lib/scripts/create_logs_config.py $BUILD_DIR/datadog/scripts/create_logs_config.py
 cp -r $ROOT_DIR/lib/test-endpoint.sh $BUILD_DIR/.profile.d/00-test-endpoint.sh # Make sure this is sourced first
-cp $ROOT_DIR/lib/redirect-logs.sh $BUILD_DIR/.profile.d/01-redirect-logs.sh
-cp $ROOT_DIR/lib/run-datadog.sh $BUILD_DIR/.profile.d/02-run-datadog.sh
+cp $ROOT_DIR/lib/run-datadog.sh $BUILD_DIR/.profile.d/01-run-datadog.sh
+cp $ROOT_DIR/lib/redirect-logs.sh $BUILD_DIR/.profile.d/02-redirect-logs.sh
 
 if [ -f $BUILD_DIR/datadog/agent ]; then
   chmod +x $BUILD_DIR/datadog/agent
@@ -36,5 +36,5 @@ if [ -f $BUILD_DIR/datadog/dogstatsd ]; then
 fi
 chmod +x $BUILD_DIR/datadog/trace-agent
 chmod +x $BUILD_DIR/.profile.d/00-test-endpoint.sh
-chmod +x $BUILD_DIR/.profile.d/01-redirect-logs.sh
-chmod +x $BUILD_DIR/.profile.d/02-run-datadog.sh
+chmod +x $BUILD_DIR/.profile.d/02-redirect-logs.sh
+chmod +x $BUILD_DIR/.profile.d/01-run-datadog.sh

--- a/lib/run-datadog.sh
+++ b/lib/run-datadog.sh
@@ -87,15 +87,15 @@ start_datadog() {
         export DD_LOG_FILE=$DATADOG_DIR/agent.log
         export DD_IOT_HOST=false
         sed -i "s~log_file: AGENT_LOG_FILE~log_file: $DD_LOG_FILE~" $DATADOG_DIR/dist/datadog.yaml
-        ./agent run --cfgpath $DATADOG_DIR/dist/ --pidfile $DATADOG_DIR/run/agent.pid &
+        ./agent run --cfgpath $DATADOG_DIR/dist/ --pidfile $DATADOG_DIR/run/agent.pid > /dev/null 2>&1 &
       fi
     else
       export DD_LOG_FILE=$DATADOG_DIR/dogstatsd.log
       sed -i "s~log_file: AGENT_LOG_FILE~log_file: $DD_LOG_FILE~" $DATADOG_DIR/dist/datadog.yaml
-      ./dogstatsd start --cfgpath $DATADOG_DIR/dist/ &
+      ./dogstatsd start --cfgpath $DATADOG_DIR/dist/ > /dev/null 2>&1 &
       echo $! > run/dogstatsd.pid
     fi
-    ./trace-agent --config $DATADOG_DIR/dist/datadog.yaml --pid $DATADOG_DIR/run/trace-agent.pid &
+    ./trace-agent --config $DATADOG_DIR/dist/datadog.yaml --pid $DATADOG_DIR/run/trace-agent.pid > /dev/null 2>&1 &
   popd
 }
 


### PR DESCRIPTION
In some cases, when an app outputs very verbose logs to stdout on startup, and logs agent is enabled, it could prevent the agent from starting as it's also trying to write to stdout, and thus prevent the logs redirection to actually consume the stdout content, resulting in a deadlock.

This fixes that by first starting the agent before the logs redirection, and removing the agent output since it's going to a file anyway.