### PR TITLE
Fix reading duplicate logs configuration

### DIFF
--- a/lib/run-datadog.sh
+++ b/lib/run-datadog.sh
@@ -21,7 +21,6 @@ start_datadog() {
     # create and configure set /conf.d if integrations are enabled
     if [ "$DD_ENABLE_CHECKS" = "true" ] || [ -n "$LOGS_CONFIG" ] ; then
       mkdir $DATADOG_DIR/dist/conf.d
-      sed -i "s~# confd_path:.*~confd_path: $DATADOG_DIR/dist/conf.d~" $DATADOG_DIR/dist/datadog.yaml
     fi
 
     # add checks configs


### PR DESCRIPTION
`dist/conf.d` folder is already checked by default, no need to configure it in the agent conf
Fixes reading twice the logs configuration and stop printing the following error:
```
2021-04-26 15:08:52 PDT | CORE | INFO | (pkg/logs/input/listener/tcp.go:48 in Start) | Starting TCP forwarder on port 11005, with read buffer size: 9000
2021-04-26 15:08:52 PDT | CORE | INFO | (pkg/logs/input/listener/tcp.go:48 in Start) | Starting TCP forwarder on port 11005, with read buffer size: 9000
2021-04-26 15:08:52 PDT | CORE | ERROR | (pkg/logs/input/listener/tcp.go:51 in Start) | Can't start TCP forwarder on port 11005: listen tcp :11005: bind: address already in use
```