### PR TITLE
Install Datadog bits in hidden folder to avoid interfering with some buildpack detection mechanism

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -10,31 +10,31 @@ ENV_DIR=$3
 
 echo "       Installing Datadog IOT Agent, Dogstatsd and Trace Agent"
 
-mkdir -p $BUILD_DIR/datadog/scripts
+mkdir -p $BUILD_DIR/.datadog/scripts
 mkdir -p $BUILD_DIR/.profile.d
 
-cp -r $ROOT_DIR/lib/dist $BUILD_DIR/datadog/
-cp -r $ROOT_DIR/lib/conf.d $BUILD_DIR/datadog/
+cp -r $ROOT_DIR/lib/dist $BUILD_DIR/.datadog/
+cp -r $ROOT_DIR/lib/conf.d $BUILD_DIR/.datadog/
 if [ -f $ROOT_DIR/lib/agent ]; then
-  cp $ROOT_DIR/lib/agent $BUILD_DIR/datadog/agent
+  cp $ROOT_DIR/lib/agent $BUILD_DIR/.datadog/agent
 fi
 if [ -f $ROOT_DIR/lib/dogstatsd ]; then
-  cp $ROOT_DIR/lib/dogstatsd $BUILD_DIR/datadog/dogstatsd
+  cp $ROOT_DIR/lib/dogstatsd $BUILD_DIR/.datadog/dogstatsd
 fi
-cp $ROOT_DIR/lib/trace-agent $BUILD_DIR/datadog/trace-agent
-cp $ROOT_DIR/lib/scripts/get_tags.py $BUILD_DIR/datadog/scripts/get_tags.py
-cp $ROOT_DIR/lib/scripts/create_logs_config.py $BUILD_DIR/datadog/scripts/create_logs_config.py
+cp $ROOT_DIR/lib/trace-agent $BUILD_DIR/.datadog/trace-agent
+cp $ROOT_DIR/lib/scripts/get_tags.py $BUILD_DIR/.datadog/scripts/get_tags.py
+cp $ROOT_DIR/lib/scripts/create_logs_config.py $BUILD_DIR/.datadog/scripts/create_logs_config.py
 cp -r $ROOT_DIR/lib/test-endpoint.sh $BUILD_DIR/.profile.d/00-test-endpoint.sh # Make sure this is sourced first
 cp $ROOT_DIR/lib/redirect-logs.sh $BUILD_DIR/.profile.d/01-redirect-logs.sh
 cp $ROOT_DIR/lib/run-datadog.sh $BUILD_DIR/.profile.d/02-run-datadog.sh
 
-if [ -f $BUILD_DIR/datadog/agent ]; then
-  chmod +x $BUILD_DIR/datadog/agent
+if [ -f $BUILD_DIR/.datadog/agent ]; then
+  chmod +x $BUILD_DIR/.datadog/agent
 fi
-if [ -f $BUILD_DIR/datadog/dogstatsd ]; then
-  chmod +x $BUILD_DIR/datadog/dogstatsd
+if [ -f $BUILD_DIR/.datadog/dogstatsd ]; then
+  chmod +x $BUILD_DIR/.datadog/dogstatsd
 fi
-chmod +x $BUILD_DIR/datadog/trace-agent
+chmod +x $BUILD_DIR/.datadog/trace-agent
 chmod +x $BUILD_DIR/.profile.d/00-test-endpoint.sh
 chmod +x $BUILD_DIR/.profile.d/01-redirect-logs.sh
 chmod +x $BUILD_DIR/.profile.d/02-run-datadog.sh

--- a/bin/supply
+++ b/bin/supply
@@ -10,31 +10,31 @@ ENV_DIR=$3
 
 echo "Installing Datadog IOT Agent, Dogstatsd and Trace Agent"
 
-mkdir -p $BUILD_DIR/datadog/scripts
+mkdir -p $BUILD_DIR/.datadog/scripts
 mkdir -p $BUILD_DIR/.profile.d
 
-cp -r $ROOT_DIR/lib/dist $BUILD_DIR/datadog/
-cp -r $ROOT_DIR/lib/conf.d $BUILD_DIR/datadog/
+cp -r $ROOT_DIR/lib/dist $BUILD_DIR/.datadog/
+cp -r $ROOT_DIR/lib/conf.d $BUILD_DIR/.datadog/
 if [ -f $ROOT_DIR/lib/agent ]; then
-  cp $ROOT_DIR/lib/agent $BUILD_DIR/datadog/agent
+  cp $ROOT_DIR/lib/agent $BUILD_DIR/.datadog/agent
 fi
 if [ -f $ROOT_DIR/lib/dogstatsd ]; then
-  cp $ROOT_DIR/lib/dogstatsd $BUILD_DIR/datadog/dogstatsd
+  cp $ROOT_DIR/lib/dogstatsd $BUILD_DIR/.datadog/dogstatsd
 fi
-cp $ROOT_DIR/lib/trace-agent $BUILD_DIR/datadog/trace-agent
-cp $ROOT_DIR/lib/scripts/get_tags.py $BUILD_DIR/datadog/scripts/get_tags.py
-cp $ROOT_DIR/lib/scripts/create_logs_config.py $BUILD_DIR/datadog/scripts/create_logs_config.py
+cp $ROOT_DIR/lib/trace-agent $BUILD_DIR/.datadog/trace-agent
+cp $ROOT_DIR/lib/scripts/get_tags.py $BUILD_DIR/.datadog/scripts/get_tags.py
+cp $ROOT_DIR/lib/scripts/create_logs_config.py $BUILD_DIR/.datadog/scripts/create_logs_config.py
 cp -r $ROOT_DIR/lib/test-endpoint.sh $BUILD_DIR/.profile.d/00-test-endpoint.sh # Make sure this is sourced first
 cp $ROOT_DIR/lib/run-datadog.sh $BUILD_DIR/.profile.d/01-run-datadog.sh
 cp $ROOT_DIR/lib/redirect-logs.sh $BUILD_DIR/.profile.d/02-redirect-logs.sh
 
-if [ -f $BUILD_DIR/datadog/agent ]; then
-  chmod +x $BUILD_DIR/datadog/agent
+if [ -f $BUILD_DIR/.datadog/agent ]; then
+  chmod +x $BUILD_DIR/.datadog/agent
 fi
-if [ -f $BUILD_DIR/datadog/dogstatsd ]; then
-  chmod +x $BUILD_DIR/datadog/dogstatsd
+if [ -f $BUILD_DIR/.datadog/dogstatsd ]; then
+  chmod +x $BUILD_DIR/.datadog/dogstatsd
 fi
-chmod +x $BUILD_DIR/datadog/trace-agent
+chmod +x $BUILD_DIR/.datadog/trace-agent
 chmod +x $BUILD_DIR/.profile.d/00-test-endpoint.sh
 chmod +x $BUILD_DIR/.profile.d/02-redirect-logs.sh
 chmod +x $BUILD_DIR/.profile.d/01-run-datadog.sh

--- a/lib/redirect-logs.sh
+++ b/lib/redirect-logs.sh
@@ -7,7 +7,7 @@
 export LOGS_CONFIG
 export STD_LOG_COLLECTION_PORT
 
-DATADOG_DIR="${DATADOG_DIR:-/home/vcap/app/datadog}"
+DATADOG_DIR="${DATADOG_DIR:-/home/vcap/app/.datadog}"
 
 DD_EU_API_SITE="https://api.datadoghq.eu/api/"
 DD_US_API_SITE="https://api.datadoghq.com/api/"

--- a/lib/run-datadog.sh
+++ b/lib/run-datadog.sh
@@ -6,7 +6,7 @@
 
 # Start dogstatsd
 
-DATADOG_DIR="${DATADOG_DIR:-/home/vcap/app/datadog}"
+DATADOG_DIR="${DATADOG_DIR:-/home/vcap/app/.datadog}"
 SUPPRESS_DD_AGENT_OUTPUT="${SUPPRESS_DD_AGENT_OUTPUT:-true}"
 
 start_datadog() {

--- a/lib/test-endpoint.sh
+++ b/lib/test-endpoint.sh
@@ -5,7 +5,7 @@
 # Copyright 2017-Present Datadog, Inc.
 
 unset DD_LOGS_VALID_ENDPOINT
-DATADOG_DIR="${DATADOG_DIR:-/home/vcap/app/datadog}"
+DATADOG_DIR="${DATADOG_DIR:-/home/vcap/app/.datadog}"
 DD_EU_API_SITE="https://api.datadoghq.eu/api/"
 DD_US_API_SITE="https://api.datadoghq.com/api/"
 DD_API_SITE=$DD_US_API_SITE


### PR DESCRIPTION
### What does this PR do?

Install the Datadog agents in a hidden folder in the app directory on the container.
Having it as a regular folder could prevent some buildpack detection mechanism to fail because of this added folder. This is the case for the Play framework in the `java_buildpack` for instance.
<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->
