### PR TITLE
Avoid losing log lines when app sparsely writes to STDOUT

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -26,8 +26,8 @@ cp $ROOT_DIR/lib/scripts/get_tags.py $BUILD_DIR/.datadog/scripts/get_tags.py
 cp $ROOT_DIR/lib/scripts/create_logs_config.py $BUILD_DIR/.datadog/scripts/create_logs_config.py
 cp $ROOT_DIR/lib/scripts/nc.py $BUILD_DIR/.datadog/scripts/nc.py
 cp -r $ROOT_DIR/lib/test-endpoint.sh $BUILD_DIR/.profile.d/00-test-endpoint.sh # Make sure this is sourced first
-cp $ROOT_DIR/lib/redirect-logs.sh $BUILD_DIR/.profile.d/01-redirect-logs.sh
-cp $ROOT_DIR/lib/run-datadog.sh $BUILD_DIR/.profile.d/02-run-datadog.sh
+cp $ROOT_DIR/lib/run-datadog.sh $BUILD_DIR/.profile.d/01-run-datadog.sh
+cp $ROOT_DIR/lib/redirect-logs.sh $BUILD_DIR/.profile.d/02-redirect-logs.sh
 
 if [ -f $BUILD_DIR/.datadog/agent ]; then
   chmod +x $BUILD_DIR/.datadog/agent
@@ -37,5 +37,5 @@ if [ -f $BUILD_DIR/.datadog/dogstatsd ]; then
 fi
 chmod +x $BUILD_DIR/.datadog/trace-agent
 chmod +x $BUILD_DIR/.profile.d/00-test-endpoint.sh
-chmod +x $BUILD_DIR/.profile.d/01-redirect-logs.sh
-chmod +x $BUILD_DIR/.profile.d/02-run-datadog.sh
+chmod +x $BUILD_DIR/.profile.d/02-redirect-logs.sh
+chmod +x $BUILD_DIR/.profile.d/01-run-datadog.sh

--- a/bin/compile
+++ b/bin/compile
@@ -24,6 +24,7 @@ fi
 cp $ROOT_DIR/lib/trace-agent $BUILD_DIR/.datadog/trace-agent
 cp $ROOT_DIR/lib/scripts/get_tags.py $BUILD_DIR/.datadog/scripts/get_tags.py
 cp $ROOT_DIR/lib/scripts/create_logs_config.py $BUILD_DIR/.datadog/scripts/create_logs_config.py
+cp $ROOT_DIR/lib/scripts/nc.py $BUILD_DIR/.datadog/scripts/nc.py
 cp -r $ROOT_DIR/lib/test-endpoint.sh $BUILD_DIR/.profile.d/00-test-endpoint.sh # Make sure this is sourced first
 cp $ROOT_DIR/lib/redirect-logs.sh $BUILD_DIR/.profile.d/01-redirect-logs.sh
 cp $ROOT_DIR/lib/run-datadog.sh $BUILD_DIR/.profile.d/02-run-datadog.sh

--- a/bin/supply
+++ b/bin/supply
@@ -24,6 +24,7 @@ fi
 cp $ROOT_DIR/lib/trace-agent $BUILD_DIR/.datadog/trace-agent
 cp $ROOT_DIR/lib/scripts/get_tags.py $BUILD_DIR/.datadog/scripts/get_tags.py
 cp $ROOT_DIR/lib/scripts/create_logs_config.py $BUILD_DIR/.datadog/scripts/create_logs_config.py
+cp $ROOT_DIR/lib/scripts/nc.py $BUILD_DIR/.datadog/scripts/nc.py
 cp -r $ROOT_DIR/lib/test-endpoint.sh $BUILD_DIR/.profile.d/00-test-endpoint.sh # Make sure this is sourced first
 cp $ROOT_DIR/lib/run-datadog.sh $BUILD_DIR/.profile.d/01-run-datadog.sh
 cp $ROOT_DIR/lib/redirect-logs.sh $BUILD_DIR/.profile.d/02-redirect-logs.sh

--- a/lib/redirect-logs.sh
+++ b/lib/redirect-logs.sh
@@ -20,7 +20,7 @@ fi
 # redirect forwards all standard inputs to a TCP socket listening on port STD_LOG_COLLECTION_PORT.
 redirect() {
   while kill -0 $$; do
-    nc localhost $STD_LOG_COLLECTION_PORT || sleep 0.5
+    python "$DATADOG_DIR/scripts/nc.py" "$STD_LOG_COLLECTION_PORT" || sleep 0.5
     echo "Resetting buildpack log redirection"
     if [ "$DD_DEBUG_STD_REDIRECTION" = "true" ]; then
       HTTP_PROXY=$DD_HTTP_PROXY HTTPS_PROXY=$DD_HTTPS_PROXY NO_PROXY=$DD_NO_PROXY curl \

--- a/lib/redirect-logs.sh
+++ b/lib/redirect-logs.sh
@@ -20,7 +20,11 @@ fi
 # redirect forwards all standard inputs to a TCP socket listening on port STD_LOG_COLLECTION_PORT.
 redirect() {
   while kill -0 $$; do
-    python "$DATADOG_DIR/scripts/nc.py" "$STD_LOG_COLLECTION_PORT" || sleep 0.5
+    if [ "$DD_SPARSE_APP_LOGS" = "true" ]; then
+        python "$DATADOG_DIR/scripts/nc.py" "$STD_LOG_COLLECTION_PORT" || sleep 0.5
+    else
+        nc localhost "$STD_LOG_COLLECTION_PORT" || sleep 0.5
+    fi
     echo "Resetting buildpack log redirection"
     if [ "$DD_DEBUG_STD_REDIRECTION" = "true" ]; then
       HTTP_PROXY=$DD_HTTP_PROXY HTTPS_PROXY=$DD_HTTPS_PROXY NO_PROXY=$DD_NO_PROXY curl \

--- a/lib/scripts/nc.py
+++ b/lib/scripts/nc.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python
+
+import os
+import socket
+import sys
+import threading
+
+
+class Sender(threading.Thread):
+    def __init__(self, sock):
+        super(Sender, self).__init__()
+        self.sock = sock
+
+    def run(self):
+        line = sys.stdin.readline()
+        while line:
+            try:
+                sock.sendall(line)
+            except Exception as e:
+                try:
+                    sock.shutdown(socket.SHUT_RDWR)
+                    sock.close()
+                except Exception:
+                    pass
+                exit(1)
+            line = sys.stdin.readline()
+
+
+try:
+    sock = socket.create_connection(("localhost", sys.argv[1]), timeout=None)
+except Exception as e:
+    exit(1)
+
+sender = Sender(sock)
+sender.daemon = True
+sender.start()
+
+# HACK: Try to read from the socket, which will block as long as the connection is OK since
+# the agent isn't sending anything on the connection. As soon as this returns, it means the
+# connection was closed on the other end (agent times out the connection if it does not receive
+# logs during 1 minute). This is to prevent losing logs because after such a disconnect, the first
+# message sent on the socket will succeed, even though it cannot possibly have been received.
+try:
+    sock.recv(1)
+    sock.shutdown(socket.SHUT_RDWR)
+    sock.close()
+except Exception:
+    pass
+exit(1)


### PR DESCRIPTION
### What does this PR do?

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

Add an option to use a custom python script to replace netcat for forwarding logs to agent. 
Setting `DD_SPARSE_APP_LOGS=true` enables this script, and prevent losing some log lines when the app writes to its STDOUT very sparsely (less than 1 log a minute), which causes the agent to close its TCP connection, and to lose the next log line that is printed to STDOUT because of some netcat behaviour.



### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Implementation is likely less efficient than netcat, but since it's supposed to be used when there are very few logs, it should be fine

### Verification Process

Manual testing
<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

If an app writes very few lines to STDOUT (less than one a minute), set the environment variable `DD_SPARSE_APP_LOGS` to `true` to avoid losing log lines. 

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
