### PR TITLE
Fix APM and Infrastructure correlation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 # do not save the completed zip files
 *.zip
-# do not save the dogstatsd binary
-lib/dogstatsd
 lib/agent
 lib/trace-agent
 lib/vector

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 lib/dogstatsd
 lib/agent
 lib/trace-agent
+lib/vector
 venv
 tmp
 .DS_Store

--- a/bin/compile
+++ b/bin/compile
@@ -37,6 +37,7 @@ if [ -f $BUILD_DIR/.datadog/dogstatsd ]; then
   chmod +x $BUILD_DIR/.datadog/dogstatsd
 fi
 chmod +x $BUILD_DIR/.datadog/trace-agent
+chmod +x $BUILD_DIR/.datadog/vector
 chmod +x $BUILD_DIR/.profile.d/00-test-endpoint.sh
 chmod +x $BUILD_DIR/.profile.d/02-redirect-logs.sh
 chmod +x $BUILD_DIR/.profile.d/01-run-datadog.sh

--- a/bin/compile
+++ b/bin/compile
@@ -8,7 +8,7 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
 
-echo "       Installing Datadog IOT Agent, Dogstatsd and Trace Agent"
+echo "       Installing Datadog IOT Agent, Vector and Trace Agent"
 
 mkdir -p $BUILD_DIR/.datadog/scripts
 mkdir -p $BUILD_DIR/.profile.d
@@ -17,9 +17,6 @@ cp -r $ROOT_DIR/lib/dist $BUILD_DIR/.datadog/
 cp -r $ROOT_DIR/lib/conf.d $BUILD_DIR/.datadog/
 if [ -f $ROOT_DIR/lib/agent ]; then
   cp $ROOT_DIR/lib/agent $BUILD_DIR/.datadog/agent
-fi
-if [ -f $ROOT_DIR/lib/dogstatsd ]; then
-  cp $ROOT_DIR/lib/dogstatsd $BUILD_DIR/.datadog/dogstatsd
 fi
 cp $ROOT_DIR/lib/trace-agent $BUILD_DIR/.datadog/trace-agent
 cp $ROOT_DIR/lib/vector $BUILD_DIR/.datadog/vector
@@ -32,9 +29,6 @@ cp $ROOT_DIR/lib/redirect-logs.sh $BUILD_DIR/.profile.d/02-redirect-logs.sh
 
 if [ -f $BUILD_DIR/.datadog/agent ]; then
   chmod +x $BUILD_DIR/.datadog/agent
-fi
-if [ -f $BUILD_DIR/.datadog/dogstatsd ]; then
-  chmod +x $BUILD_DIR/.datadog/dogstatsd
 fi
 chmod +x $BUILD_DIR/.datadog/trace-agent
 chmod +x $BUILD_DIR/.datadog/vector

--- a/bin/compile
+++ b/bin/compile
@@ -22,6 +22,7 @@ if [ -f $ROOT_DIR/lib/dogstatsd ]; then
   cp $ROOT_DIR/lib/dogstatsd $BUILD_DIR/.datadog/dogstatsd
 fi
 cp $ROOT_DIR/lib/trace-agent $BUILD_DIR/.datadog/trace-agent
+cp $ROOT_DIR/lib/vector $BUILD_DIR/.datadog/vector
 cp $ROOT_DIR/lib/scripts/get_tags.py $BUILD_DIR/.datadog/scripts/get_tags.py
 cp $ROOT_DIR/lib/scripts/create_logs_config.py $BUILD_DIR/.datadog/scripts/create_logs_config.py
 cp $ROOT_DIR/lib/scripts/nc.py $BUILD_DIR/.datadog/scripts/nc.py

--- a/bin/supply
+++ b/bin/supply
@@ -22,6 +22,7 @@ if [ -f $ROOT_DIR/lib/dogstatsd ]; then
   cp $ROOT_DIR/lib/dogstatsd $BUILD_DIR/.datadog/dogstatsd
 fi
 cp $ROOT_DIR/lib/trace-agent $BUILD_DIR/.datadog/trace-agent
+cp $ROOT_DIR/lib/vector $BUILD_DIR/.datadog/vector
 cp $ROOT_DIR/lib/scripts/get_tags.py $BUILD_DIR/.datadog/scripts/get_tags.py
 cp $ROOT_DIR/lib/scripts/create_logs_config.py $BUILD_DIR/.datadog/scripts/create_logs_config.py
 cp $ROOT_DIR/lib/scripts/nc.py $BUILD_DIR/.datadog/scripts/nc.py
@@ -36,6 +37,7 @@ if [ -f $BUILD_DIR/.datadog/dogstatsd ]; then
   chmod +x $BUILD_DIR/.datadog/dogstatsd
 fi
 chmod +x $BUILD_DIR/.datadog/trace-agent
+chmod +x $BUILD_DIR/.datadog/vector
 chmod +x $BUILD_DIR/.profile.d/00-test-endpoint.sh
 chmod +x $BUILD_DIR/.profile.d/02-redirect-logs.sh
 chmod +x $BUILD_DIR/.profile.d/01-run-datadog.sh

--- a/bin/supply
+++ b/bin/supply
@@ -8,7 +8,7 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
 
-echo "Installing Datadog IOT Agent, Dogstatsd and Trace Agent"
+echo "Installing Datadog IOT Agent, Vector and Trace Agent"
 
 mkdir -p $BUILD_DIR/.datadog/scripts
 mkdir -p $BUILD_DIR/.profile.d
@@ -17,9 +17,6 @@ cp -r $ROOT_DIR/lib/dist $BUILD_DIR/.datadog/
 cp -r $ROOT_DIR/lib/conf.d $BUILD_DIR/.datadog/
 if [ -f $ROOT_DIR/lib/agent ]; then
   cp $ROOT_DIR/lib/agent $BUILD_DIR/.datadog/agent
-fi
-if [ -f $ROOT_DIR/lib/dogstatsd ]; then
-  cp $ROOT_DIR/lib/dogstatsd $BUILD_DIR/.datadog/dogstatsd
 fi
 cp $ROOT_DIR/lib/trace-agent $BUILD_DIR/.datadog/trace-agent
 cp $ROOT_DIR/lib/vector $BUILD_DIR/.datadog/vector
@@ -32,9 +29,6 @@ cp $ROOT_DIR/lib/redirect-logs.sh $BUILD_DIR/.profile.d/02-redirect-logs.sh
 
 if [ -f $BUILD_DIR/.datadog/agent ]; then
   chmod +x $BUILD_DIR/.datadog/agent
-fi
-if [ -f $BUILD_DIR/.datadog/dogstatsd ]; then
-  chmod +x $BUILD_DIR/.datadog/dogstatsd
 fi
 chmod +x $BUILD_DIR/.datadog/trace-agent
 chmod +x $BUILD_DIR/.datadog/vector

--- a/build
+++ b/build
@@ -6,7 +6,6 @@ ZIPFILE="$NAME.zip"
 DOWNLOAD_BASE_URL="https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/datadog-"
 TRACEAGENT_DOWNLOAD_URL=$DOWNLOAD_BASE_URL"agent_"
 IOT_AGENT_DOWNLOAD_URL=$DOWNLOAD_BASE_URL"iot-agent_"
-DOGSTATSD_DOWNLOAD_URL=$DOWNLOAD_BASE_URL"dogstatsd_"
 DOWNLOAD_URL_TAIL="-1_amd64.deb"
 AGENT_DEFAULT_VERSION="7.35.1"
 
@@ -38,19 +37,6 @@ function download_iot_agent() {
   rm -rf $TMPDIR/*
 }
 
-function download_dogstatsd() {
-  local dogstatsd_version="${1:-$AGENT_DEFAULT_VERSION}"
-  local dogstatsd_download_url="$DOGSTATSD_DOWNLOAD_URL$dogstatsd_version$DOWNLOAD_URL_TAIL"
-
-  mkdir -p $TMPDIR
-  curl -L $dogstatsd_download_url -o ./tmp/dogstatsd.deb
-  pushd $TMPDIR
-    dpkg -x dogstatsd.deb .
-  popd
-  cp $TMPDIR/opt/datadog-dogstatsd/bin/dogstatsd $SRCDIR/lib/dogstatsd
-  rm -rf $TMPDIR/*
-}
-
 function download_vector() {
   mkdir -p $TMPDIR/vector && \
   curl -sSfL --proto '=https' --tlsv1.2 https://packages.timber.io/vector/0.21.2/vector-0.21.2-x86_64-unknown-linux-musl.tar.gz  | \
@@ -61,7 +47,7 @@ function download_vector() {
 }
 
 function main() {
-  if [ ! -f $SRCDIR/lib/dogstatsd ] || [ ! -f $SRCDIR/lib/trace-agent ]; then
+  if [ ! -f $SRCDIR/lib/vector ] || [ ! -f $SRCDIR/lib/trace-agent ]; then
     DOWNLOAD="true"
   fi
   if [ -n "$IOT_AGENT" ] && [ ! -f $SRCDIR/lib/agent ]; then
@@ -73,7 +59,6 @@ function main() {
   if [ -n "$DOWNLOAD" ]; then
     # Delete the old ones
     rm -f $SRCDIR/lib/agent
-    rm -f $SRCDIR/lib/dogstatsd
     rm -f $SRCDIR/lib/trace-agent
     rm -f $SRCDIR/lib/vector
 
@@ -85,9 +70,6 @@ function main() {
 
     download_iot_agent $VERSION
     chmod +x $SRCDIR/lib/agent
-
-    download_dogstatsd $VERSION
-    chmod +x $SRCDIR/lib/dogstatsd
 
     download_vector
     chmod +x $SRCDIR/lib/vector

--- a/build
+++ b/build
@@ -51,6 +51,15 @@ function download_dogstatsd() {
   rm -rf $TMPDIR/*
 }
 
+function download_vector() {
+  mkdir -p $TMPDIR/vector && \
+  curl -sSfL --proto '=https' --tlsv1.2 https://packages.timber.io/vector/0.21.2/vector-0.21.2-x86_64-unknown-linux-musl.tar.gz  | \
+  tar xzf - -C $TMPDIR/vector --strip-components=2
+
+  mv $TMPDIR/vector/bin/vector $SRCDIR/lib/vector
+  rm -rf $TMPDIR/*
+}
+
 function main() {
   if [ ! -f $SRCDIR/lib/dogstatsd ] || [ ! -f $SRCDIR/lib/trace-agent ]; then
     DOWNLOAD="true"
@@ -66,6 +75,7 @@ function main() {
     rm -f $SRCDIR/lib/agent
     rm -f $SRCDIR/lib/dogstatsd
     rm -f $SRCDIR/lib/trace-agent
+    rm -f $SRCDIR/lib/vector
 
     # Download the new ones
     VERSION=${VERSION:-$AGENT_DEFAULT_VERSION}
@@ -78,6 +88,9 @@ function main() {
 
     download_dogstatsd $VERSION
     chmod +x $SRCDIR/lib/dogstatsd
+
+    download_vector
+    chmod +x $SRCDIR/lib/vector
   fi
 
   rm -f $ZIPFILE

--- a/lib/dist/vector.toml
+++ b/lib/dist/vector.toml
@@ -1,7 +1,12 @@
 [sources.app_logs]
 type = "stdin"
 
-[transforms.with_dd_metadata]
+[sources.app_metrics]
+type = "statsd"
+address = "0.0.0.0:8125"
+mode = "udp"
+
+[transforms.logs_with_dd_metadata]
 type = "remap"
 inputs = ["app_logs"]
 source = '''
@@ -11,11 +16,37 @@ source = '''
 .host="$VM_HOSTNAME"
 '''
 
+[transforms.metrics_with_dd_metadata]
+type = "remap"
+inputs = ["app_metrics"]
+source = '''
+.tags="$DD_TAGS"
+'''
+
 [sinks.dd_logs]
 type = "datadog_logs"
-inputs = [ "with_dd_metadata" ]
+inputs = [ "logs_with_dd_metadata" ]
 default_api_key = "$DD_API_KEY"
 compression = "gzip"
 
+[sinks.dd_metrics]
+type = "datadog_metrics"
+inputs = [ "metrics_with_dd_metadata" ]
+api_key = "$DD_API_KEY"
+
+# vector configuration for better debugging
 [api]
 enabled = true
+
+[sources.internal_logs]
+type = "internal_logs"
+
+[sinks.vector_logs]
+type = "file"
+inputs = [ "internal_logs" ]
+compression = "none"
+path = "./vector.log"
+
+  [sinks.vector_logs.encoding]
+  codec = "text"
+

--- a/lib/dist/vector.toml
+++ b/lib/dist/vector.toml
@@ -8,6 +8,7 @@ source = '''
 .service="$DD_SERVICE"
 .ddsource="$DD_LOG_SOURCE"
 .ddtags="$DD_TAGS"
+.host="$VM_HOSTNAME"
 '''
 
 [sinks.dd_logs]

--- a/lib/dist/vector.toml
+++ b/lib/dist/vector.toml
@@ -1,0 +1,20 @@
+[sources.app_logs]
+type = "stdin"
+
+[transforms.with_dd_metadata]
+type = "remap"
+inputs = ["app_logs"]
+source = '''
+.service="$DD_SERVICE"
+.ddsource="$DD_LOG_SOURCE"
+.ddtags="$DD_TAGS"
+'''
+
+[sinks.dd_logs]
+type = "datadog_logs"
+inputs = [ "with_dd_metadata" ]
+default_api_key = "$DD_API_KEY"
+compression = "gzip"
+
+[api]
+enabled = true

--- a/lib/redirect-logs.sh
+++ b/lib/redirect-logs.sh
@@ -42,5 +42,7 @@ redirect() {
 
 pushd $DATADOG_DIR
 echo "forward all logs from stdout/stderr to vector"
-exec &> >(./vector --config $DATADOG_DIR/dist/vector.toml)
+
+IFS=. read -a VM_HOSTNAME <<< $(host $CF_INSTANCE_IP | awk '{print $5}')
+exec &> >(VM_HOSTNAME=$VM_HOSTNAME ./vector --config $DATADOG_DIR/dist/vector.toml)
 popd

--- a/lib/redirect-logs.sh
+++ b/lib/redirect-logs.sh
@@ -42,5 +42,5 @@ redirect() {
 
 pushd $DATADOG_DIR
 echo "forward all logs from stdout/stderr to vector"
-exec &> >(./vector --config ./dist/vector.toml)
+exec &> >(./vector --config $DATADOG_DIR/dist/vector.toml)
 popd

--- a/lib/redirect-logs.sh
+++ b/lib/redirect-logs.sh
@@ -43,6 +43,10 @@ redirect() {
 pushd $DATADOG_DIR
 echo "forward all logs from stdout/stderr to vector"
 
+DD_TAGS=$(LEGACY_TAGS_FORMAT=true OVERRIDE_DD_HOSTNAME=true python $DATADOG_DIR/scripts/get_tags.py)
+
+echo "DD_TAGS:$DD_TAGS"
+
 IFS=. read -a VM_HOSTNAME <<< $(host $CF_INSTANCE_IP | awk '{print $5}')
-exec &> >(VM_HOSTNAME=$VM_HOSTNAME ./vector --config $DATADOG_DIR/dist/vector.toml)
+exec &> >(VM_HOSTNAME=$VM_HOSTNAME DD_TAGS=$(LEGACY_TAGS_FORMAT=true OVERRIDE_DD_HOSTNAME=true python $DATADOG_DIR/scripts/get_tags.py) ./vector --config $DATADOG_DIR/dist/vector.toml)
 popd

--- a/lib/redirect-logs.sh
+++ b/lib/redirect-logs.sh
@@ -40,19 +40,7 @@ redirect() {
   done
 }
 
-# setup the redirection from stdout/stderr to the logs-agent.
-if [ "$DD_LOGS_ENABLED" = "true" ]; then
-  if [ "$DD_LOGS_VALID_ENDPOINT" = "false" ]; then
-    echo "Log endpoint not valid, not starting log redirection"
-  else
-    if [ -z "$LOGS_CONFIG" ]; then
-      echo "can't collect logs, LOGS_CONFIG is not set"
-    else
-      echo "collect all logs for config $LOGS_CONFIG"
-      if [ -n "$STD_LOG_COLLECTION_PORT" ]; then
-        echo "forward all logs from stdout/stderr to agent port $STD_LOG_COLLECTION_PORT"
-        exec &> >(tee >(redirect))
-      fi
-    fi
-  fi
-fi
+pushd $DATADOG_DIR
+echo "forward all logs from stdout/stderr to vector"
+exec &> >(./vector --config ./dist/vector.toml)
+popd

--- a/lib/run-datadog.sh
+++ b/lib/run-datadog.sh
@@ -43,7 +43,7 @@ start_datadog() {
     sed -i "s~# tags:.*~tags: $datadog_tags~" $DATADOG_DIR/dist/datadog.yaml
     sed -i "s~log_file: TRACE_LOG_FILE~log_file: $DATADOG_DIR/trace.log~" $DATADOG_DIR/dist/datadog.yaml
 
-    # set the hostname to the host VM
+    # set the agent hostname to the host VM hostname
     IFS=. read -a VM_HOSTNAME <<< $(host $CF_INSTANCE_IP | awk '{print $5}')
     sed -i "s~# hostname: mymachine.mydomain~hostname: $VM_HOSTNAME~" $DATADOG_DIR/dist/datadog.yaml
 

--- a/lib/run-datadog.sh
+++ b/lib/run-datadog.sh
@@ -46,8 +46,9 @@ start_datadog() {
     # set the agent hostname to the host VM hostname
     host $CF_INSTANCE_IP
     if [ $? -ne 0 ]; then
+        cp $DATADOG_DIR/dist/datadog.yaml $DATADOG_DIR/dist/datadog_trace.yaml
         IFS=. read -a VM_HOSTNAME <<< $(host $CF_INSTANCE_IP | awk '{print $5}')
-        sed -i "s~# hostname: mymachine.mydomain~hostname: $VM_HOSTNAME~" $DATADOG_DIR/dist/datadog.yaml
+        sed -i "s~# hostname: mymachine.mydomain~hostname: $VM_HOSTNAME~" $DATADOG_DIR/dist/datadog_trace.yaml
     fi
 
     if [ -n "$DD_SKIP_SSL_VALIDATION" ]; then
@@ -114,9 +115,9 @@ start_datadog() {
     echo $! > run/dogstatsd.pid
 
     if [ "$SUPPRESS_DD_AGENT_OUTPUT" = "true" ]; then
-      ./trace-agent --config $DATADOG_DIR/dist/datadog.yaml --pid $DATADOG_DIR/run/trace-agent.pid > /dev/null 2>&1 &
+      ./trace-agent --config $DATADOG_DIR/dist/datadog_trace.yaml --pid $DATADOG_DIR/run/trace-agent.pid > /dev/null 2>&1 &
     else
-      ./trace-agent --config $DATADOG_DIR/dist/datadog.yaml --pid $DATADOG_DIR/run/trace-agent.pid &
+      ./trace-agent --config $DATADOG_DIR/dist/datadog_trace.yaml --pid $DATADOG_DIR/run/trace-agent.pid &
     fi
   popd
 }

--- a/lib/run-datadog.sh
+++ b/lib/run-datadog.sh
@@ -44,8 +44,11 @@ start_datadog() {
     sed -i "s~log_file: TRACE_LOG_FILE~log_file: $DATADOG_DIR/trace.log~" $DATADOG_DIR/dist/datadog.yaml
 
     # set the agent hostname to the host VM hostname
-    IFS=. read -a VM_HOSTNAME <<< $(host $CF_INSTANCE_IP | awk '{print $5}')
-    sed -i "s~# hostname: mymachine.mydomain~hostname: $VM_HOSTNAME~" $DATADOG_DIR/dist/datadog.yaml
+    host $CF_INSTANCE_IP
+    if [ $? -ne 0 ]; then
+        IFS=. read -a VM_HOSTNAME <<< $(host $CF_INSTANCE_IP | awk '{print $5}')
+        sed -i "s~# hostname: mymachine.mydomain~hostname: $VM_HOSTNAME~" $DATADOG_DIR/dist/datadog.yaml
+    fi
 
     if [ -n "$DD_SKIP_SSL_VALIDATION" ]; then
       sed -i "s~# skip_ssl_validation: no~skip_ssl_validation: yes~" $DATADOG_DIR/dist/datadog.yaml

--- a/lib/run-datadog.sh
+++ b/lib/run-datadog.sh
@@ -4,8 +4,6 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2017-Present Datadog, Inc.
 
-# Start dogstatsd
-
 DATADOG_DIR="${DATADOG_DIR:-/home/vcap/app/.datadog}"
 SUPPRESS_DD_AGENT_OUTPUT="${SUPPRESS_DD_AGENT_OUTPUT:-true}"
 LOCKFILE="$DATADOG_DIR/lock"
@@ -93,29 +91,15 @@ start_datadog() {
       fi
     fi
 
-    # DSD requires its own config file
-    cp $DATADOG_DIR/dist/datadog.yaml $DATADOG_DIR/dist/dogstatsd.yaml
-
     # trace agent own config file
     cp $DATADOG_DIR/dist/datadog.yaml $DATADOG_DIR/dist/datadog_trace.yaml
 
-    # set the trace agent and dogstatsd hostnames to the VM hostname
+    # set the trace agent and hostnames to the VM hostname
     host $CF_INSTANCE_IP
     if [ $? -eq 0 ]; then
         IFS=. read -a VM_HOSTNAME <<< $(host $CF_INSTANCE_IP | awk '{print $5}')
         sed -i "s~# hostname: mymachine.mydomain~hostname: $VM_HOSTNAME~" $DATADOG_DIR/dist/datadog_trace.yaml
-        sed -i "s~# hostname: mymachine.mydomain~hostname: $VM_HOSTNAME~" $DATADOG_DIR/dist/dogstatsd.yaml
     fi
-
-    export DSD_LOG_FILE=$DATADOG_DIR/dogstatsd.log
-    sed -i "s~log_file: AGENT_LOG_FILE~log_file: $DSD_LOG_FILE~" $DATADOG_DIR/dist/datadog.yaml
-
-    if [ "$SUPPRESS_DD_AGENT_OUTPUT" = "true" ]; then
-      ./dogstatsd start --cfgpath $DATADOG_DIR/dist/ > /dev/null 2>&1 &
-    else
-      ./dogstatsd start --cfgpath $DATADOG_DIR/dist/ &
-    fi
-    echo $! > run/dogstatsd.pid
 
     if [ "$SUPPRESS_DD_AGENT_OUTPUT" = "true" ]; then
       ./trace-agent --config $DATADOG_DIR/dist/datadog_trace.yaml --pid $DATADOG_DIR/run/trace-agent.pid > /dev/null 2>&1 &

--- a/lib/run-datadog.sh
+++ b/lib/run-datadog.sh
@@ -15,7 +15,7 @@ start_datadog() {
     export DD_LOG_FILE=$DATADOG_DIR/dogstatsd.log
     export DD_API_KEY
     export DD_DD_URL
-    export DD_ENABLE_CHECKS="${DD_ENABLE_CHECKS:-true}"
+    export DD_ENABLE_CHECKS="${DD_ENABLE_CHECKS:-false}"
     export DOCKER_DD_AGENT=yes
     export LOGS_CONFIG_DIR=$DATADOG_DIR/dist/conf.d/logs.d
     export LOGS_CONFIG
@@ -89,14 +89,14 @@ start_datadog() {
 
     # DSD requires its own config file
     cp $DATADOG_DIR/dist/datadog.yaml $DATADOG_DIR/dist/dogstatsd.yaml
-    if [ -n "$RUN_AGENT" -a -f ./agent ]; then
-      if [ "$DD_LOGS_ENABLED" = "true" -a "$DD_LOGS_VALID_ENDPOINT" = "false" ]; then
+    if [ "$DD_LOGS_ENABLED" = "true" -a -f ./agent ]; then
+      if [ "$DD_LOGS_VALID_ENDPOINT" = "false" ]; then
         echo "Log endpoint not valid, not starting agent"
       else
         export DD_LOG_FILE=$DATADOG_DIR/agent.log
         export DD_IOT_HOST=false
         sed -i "s~log_file: AGENT_LOG_FILE~log_file: $DD_LOG_FILE~" $DATADOG_DIR/dist/datadog.yaml
-        if [ "$SUPPRESS_DD_AGENT_OUTPUT" == "true" ]; then
+        if [ "$SUPPRESS_DD_AGENT_OUTPUT" = "true" ]; then
           ./agent run --cfgpath $DATADOG_DIR/dist/ --pidfile $DATADOG_DIR/run/agent.pid > /dev/null 2>&1 &
         else
           ./agent run --cfgpath $DATADOG_DIR/dist/ --pidfile $DATADOG_DIR/run/agent.pid &
@@ -105,14 +105,14 @@ start_datadog() {
     else
       export DD_LOG_FILE=$DATADOG_DIR/dogstatsd.log
       sed -i "s~log_file: AGENT_LOG_FILE~log_file: $DD_LOG_FILE~" $DATADOG_DIR/dist/datadog.yaml
-      if [ "$SUPPRESS_DD_AGENT_OUTPUT" == "true" ]; then
+      if [ "$SUPPRESS_DD_AGENT_OUTPUT" = "true" ]; then
         ./dogstatsd start --cfgpath $DATADOG_DIR/dist/ > /dev/null 2>&1 &
       else
         ./dogstatsd start --cfgpath $DATADOG_DIR/dist/ &
       fi
       echo $! > run/dogstatsd.pid
     fi
-    if [ "$SUPPRESS_DD_AGENT_OUTPUT" == "true" ]; then
+    if [ "$SUPPRESS_DD_AGENT_OUTPUT" = "true" ]; then
       ./trace-agent --config $DATADOG_DIR/dist/datadog.yaml --pid $DATADOG_DIR/run/trace-agent.pid > /dev/null 2>&1 &
     else
       ./trace-agent --config $DATADOG_DIR/dist/datadog.yaml --pid $DATADOG_DIR/run/trace-agent.pid &

--- a/lib/run-datadog.sh
+++ b/lib/run-datadog.sh
@@ -42,6 +42,11 @@ start_datadog() {
     datadog_tags=$(python $DATADOG_DIR/scripts/get_tags.py)
     sed -i "s~# tags:.*~tags: $datadog_tags~" $DATADOG_DIR/dist/datadog.yaml
     sed -i "s~log_file: TRACE_LOG_FILE~log_file: $DATADOG_DIR/trace.log~" $DATADOG_DIR/dist/datadog.yaml
+
+    # set the hostname to the host VM
+    IFS=. read -a VM_HOSTNAME <<< $(host $CF_INSTANCE_IP | awk '{print $5}')
+    sed -i "s~# hostname: mymachine.mydomain~hostname: $VM_HOSTNAME~" $DATADOG_DIR/dist/datadog.yaml
+
     if [ -n "$DD_SKIP_SSL_VALIDATION" ]; then
       sed -i "s~# skip_ssl_validation: no~skip_ssl_validation: yes~" $DATADOG_DIR/dist/datadog.yaml
     fi

--- a/lib/scripts/get_tags.py
+++ b/lib/scripts/get_tags.py
@@ -49,6 +49,11 @@ if user_tags:
     except Exception as e:
         print("there was an issue parsing the tags in DD_TAGS: {}".format(e))
 
+if os.environ.get('OVERRIDE_DD_HOSTNAME', None):
+    import socket
+    vm_hostname = socket.gethostbyaddr(cf_instance_ip)[0].split(".")[0]
+    tags.append("host:{}".format(vm_hostname))
+
 legacy_tags = os.environ.get('LEGACY_TAGS_FORMAT', False)
 if legacy_tags:
     print(','.join(tags))

--- a/lib/scripts/get_tags.py
+++ b/lib/scripts/get_tags.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 
 import os
 import json
+import socket
 
 vcap_app_string = os.environ.get('VCAP_APPLICATION', '{}')
 
@@ -24,6 +25,8 @@ for vcap_var_name in vcap_variables:
         if vcap_var_name == 'name':
             key = 'application_name'
         tags.append("{0}:{1}".format(key, vcap_var))
+
+tags.append("{0}:{1}".format("container_id", os.environ.get("CF_INSTANCE_GUID")))
 
 uris = vcap_application.get('uris')
 if uris:

--- a/lib/scripts/get_tags.py
+++ b/lib/scripts/get_tags.py
@@ -6,7 +6,6 @@ from __future__ import print_function
 
 import os
 import json
-import socket
 
 vcap_app_string = os.environ.get('VCAP_APPLICATION', '{}')
 
@@ -15,8 +14,9 @@ vcap_application = json.loads(vcap_app_string)
 vcap_variables = ["application_id", "name", "instance_index", "space_name"]
 
 cf_instance_ip = os.environ.get("CF_INSTANCE_IP")
+cf_instance_guid = os.environ.get("CF_INSTANCE_GUID")
 
-tags = ["cf_instance_ip:{}".format(cf_instance_ip)]
+tags = ["cf_instance_ip:{}".format(cf_instance_ip), "container_id:{}".format(cf_instance_guid)]
 
 for vcap_var_name in vcap_variables:
     vcap_var = vcap_application.get(vcap_var_name)
@@ -25,8 +25,6 @@ for vcap_var_name in vcap_variables:
         if vcap_var_name == 'name':
             key = 'application_name'
         tags.append("{0}:{1}".format(key, vcap_var))
-
-tags.append("{0}:{1}".format("container_id", os.environ.get("CF_INSTANCE_GUID")))
 
 uris = vcap_application.get('uris')
 if uris:


### PR DESCRIPTION
Sets the agent's hostname to the Host VM's hostname and adds a `container_id` tag.
We now use vector agent to forward logs to datadog, and only run DD agent when the checks are enabled.