### PR TITLE
Fix `DD_TAGS` format issues

### DIFF
--- a/lib/run-datadog.sh
+++ b/lib/run-datadog.sh
@@ -9,7 +9,6 @@
 DATADOG_DIR="${DATADOG_DIR:-/home/vcap/app/.datadog}"
 SUPPRESS_DD_AGENT_OUTPUT="${SUPPRESS_DD_AGENT_OUTPUT:-true}"
 LOCKFILE="$DATADOG_DIR/lock"
-export DD_TAGS=$(LEGACY_TAGS_FORMAT=true python $DATADOG_DIR/scripts/get_tags.py)
 
 start_datadog() {
   pushd $DATADOG_DIR
@@ -41,6 +40,8 @@ start_datadog() {
     # the conf file requires them to be comma separated only
     # so they must be grabbed separately
     datadog_tags=$(python $DATADOG_DIR/scripts/get_tags.py)
+    export DD_TAGS=""
+
     sed -i "s~# tags:.*~tags: $datadog_tags~" $DATADOG_DIR/dist/datadog.yaml
     sed -i "s~# dogstatsd_tags:~dogstatsd_tags: $datadog_tags~" $DATADOG_DIR/dist/datadog.yaml
     sed -i "s~log_file: TRACE_LOG_FILE~log_file: $DATADOG_DIR/trace.log~" $DATADOG_DIR/dist/datadog.yaml

--- a/lib/run-datadog.sh
+++ b/lib/run-datadog.sh
@@ -40,7 +40,7 @@ start_datadog() {
     # the conf file requires them to be comma separated only
     # so they must be grabbed separately
     datadog_tags=$(python $DATADOG_DIR/scripts/get_tags.py)
-    export DD_TAGS=""
+    unset DD_TAGS
 
     sed -i "s~# tags:.*~tags: $datadog_tags~" $DATADOG_DIR/dist/datadog.yaml
     sed -i "s~# dogstatsd_tags:~dogstatsd_tags: $datadog_tags~" $DATADOG_DIR/dist/datadog.yaml


### PR DESCRIPTION
This PR fixes an issue where `DD_TAGS` would appear as a single (long) tag.

Since the content of `DD_TAGS`  is already extracted inside the `get_tags.py` script (line 42), and injected into the agent config file `datadog.yaml`.

We should reset the env var as it's also being picked by the agent, and might cause some bugs in the tags format.