### PR TITLE
Fix `KeyError` in create_logs_config python script

### DIFF
--- a/lib/scripts/create_logs_config.py
+++ b/lib/scripts/create_logs_config.py
@@ -7,14 +7,19 @@ from __future__ import print_function
 import os
 import json
 
-LOGS_CONFIG_DIR = os.environ['LOGS_CONFIG_DIR']
-LOGS_CONFIG = os.environ['LOGS_CONFIG']
-DD_TAGS = os.environ['DD_TAGS']
+LOGS_CONFIG_DIR = os.environ.get('LOGS_CONFIG_DIR')
+LOGS_CONFIG = os.environ.get('LOGS_CONFIG')
+DD_TAGS = os.environ.get('DD_TAGS')
 
 
 config = {}
-config["logs"] = json.loads(LOGS_CONFIG)
-config["logs"][0]["tags"] = DD_TAGS
+
+if LOGS_CONFIG:
+  config["logs"] = json.loads(LOGS_CONFIG)
+
+if DD_TAGS:
+  config["logs"][0]["tags"] = DD_TAGS
+
 config = json.dumps(config)
 
 path = LOGS_CONFIG_DIR + "/logs.yaml"

--- a/lib/scripts/create_logs_config.py
+++ b/lib/scripts/create_logs_config.py
@@ -14,6 +14,10 @@ DD_TAGS = os.environ.get('DD_TAGS')
 
 config = {}
 
+if not LOGS_CONFIG_DIR:
+  print("ERROR: `LOGS_CONFIG_DIR` must be set in order to collect logs. For more info, see: https://github.com/DataDog/datadog-cloudfoundry-buildpack#log-collection")
+  exit(1)
+
 if LOGS_CONFIG:
   config["logs"] = json.loads(LOGS_CONFIG)
 

--- a/lib/scripts/create_logs_config.py
+++ b/lib/scripts/create_logs_config.py
@@ -17,8 +17,8 @@ config = {}
 if LOGS_CONFIG:
   config["logs"] = json.loads(LOGS_CONFIG)
 
-if DD_TAGS:
-  config["logs"][0]["tags"] = DD_TAGS
+  if DD_TAGS:
+    config["logs"][0]["tags"] = DD_TAGS
 
 config = json.dumps(config)
 

--- a/lib/scripts/create_logs_config.py
+++ b/lib/scripts/create_logs_config.py
@@ -19,6 +19,9 @@ if LOGS_CONFIG:
 
   if DD_TAGS:
     config["logs"][0]["tags"] = DD_TAGS
+else:
+  print("ERROR: `LOGS_CONFIG` must be set in order to collect logs. For more info, see: https://github.com/DataDog/datadog-cloudfoundry-buildpack#log-collection")
+  exit(1)
 
 config = json.dumps(config)
 


### PR DESCRIPTION
Started getting this error for nonexistent env vars on Python 3.10.x.