### PR TITLE
Set hostname to container hostname when 'DD_ENABLE_CHECKS' is enabled

### DIFF
--- a/lib/run-datadog.sh
+++ b/lib/run-datadog.sh
@@ -57,6 +57,8 @@ start_datadog() {
           IFS=. read -a VM_HOSTNAME <<< $(host $CF_INSTANCE_IP | awk '{print $5}')
           sed -i "s~# hostname: mymachine.mydomain~hostname: $VM_HOSTNAME~" $DATADOG_DIR/dist/datadog.yaml
       fi
+    else
+      sed -i "s~# hostname: mymachine.mydomain~hostname: $(hostname)~" $DATADOG_DIR/dist/datadog.yaml
     fi
 
     if [ -n "$DD_HTTP_PROXY" ]; then


### PR DESCRIPTION
Explicitly setting the hostname helps us avoid some errors in the agent e.g. `unable to reliably determine the host name. You can define one in the agent config file or in your hosts file`