### PR TITLE
Add ability to wait for the trace agent startup before application start

### DIFF
--- a/bin/supply
+++ b/bin/supply
@@ -38,7 +38,6 @@ cp "${ROOT_DIR}/lib/scripts/nc.py" "${DATADOG_DIR}/scripts/nc.py"
 cp "${ROOT_DIR}/lib/scripts/utils.sh" "${DATADOG_DIR}/scripts/utils.sh"
 cp "${ROOT_DIR}/lib/scripts/check_datadog.sh" "${DATADOG_DIR}/scripts/check_datadog.sh"
 
-
 cp -r "${ROOT_DIR}/lib/test-endpoint.sh" "${BUILD_DIR}/.profile.d/00-test-endpoint.sh" # Make sure this is sourced first
 cp "${ROOT_DIR}/lib/run-datadog.sh" "${BUILD_DIR}/.profile.d/01-run-datadog.sh"
 cp "${ROOT_DIR}/lib/redirect-logs.sh" "${BUILD_DIR}/.profile.d/02-redirect-logs.sh"
@@ -52,7 +51,6 @@ fi
 
 chmod +x "${DATADOG_DIR}/scripts/utils.sh"
 chmod +x "${DATADOG_DIR}/scripts/check_datadog.sh"
-
 
 chmod +x "${DATADOG_DIR}/trace-agent"
 chmod +x "${BUILD_DIR}/.profile.d/00-test-endpoint.sh"

--- a/bin/supply
+++ b/bin/supply
@@ -38,6 +38,7 @@ cp "${ROOT_DIR}/lib/scripts/nc.py" "${DATADOG_DIR}/scripts/nc.py"
 cp "${ROOT_DIR}/lib/scripts/utils.sh" "${DATADOG_DIR}/scripts/utils.sh"
 cp "${ROOT_DIR}/lib/scripts/check_datadog.sh" "${DATADOG_DIR}/scripts/check_datadog.sh"
 
+
 cp -r "${ROOT_DIR}/lib/test-endpoint.sh" "${BUILD_DIR}/.profile.d/00-test-endpoint.sh" # Make sure this is sourced first
 cp "${ROOT_DIR}/lib/run-datadog.sh" "${BUILD_DIR}/.profile.d/01-run-datadog.sh"
 cp "${ROOT_DIR}/lib/redirect-logs.sh" "${BUILD_DIR}/.profile.d/02-redirect-logs.sh"
@@ -51,6 +52,7 @@ fi
 
 chmod +x "${DATADOG_DIR}/scripts/utils.sh"
 chmod +x "${DATADOG_DIR}/scripts/check_datadog.sh"
+
 
 chmod +x "${DATADOG_DIR}/trace-agent"
 chmod +x "${BUILD_DIR}/.profile.d/00-test-endpoint.sh"

--- a/lib/run-datadog.sh
+++ b/lib/run-datadog.sh
@@ -235,3 +235,8 @@ main() {
   fi
 }
 main "$@"
+
+while ! nc -z localhost 8126; do   
+  echo "Waiting for the trace agent to start on 8126..."
+  sleep 1
+done

--- a/lib/run-datadog.sh
+++ b/lib/run-datadog.sh
@@ -236,9 +236,16 @@ main() {
 }
 main "$@"
 
+timeout=120
 if [ "${WAIT_DD_TRACE_AGENT}" = "true" ]; then
-  while ! nc -z localhost 8126; do   
+  while ! nc -z localhost 8126 && [ $timeout -ge 0 ]; do
     echo "Waiting for the trace agent to start on 8126..."
     sleep 1
+    timeout=$((timeout - 1))
   done
+  if [ $timeout -ge 0 ]; then
+      echo "Trace agent is listening for traces"
+  else
+      echo "Timed out waiting for the trace agent"
+  fi
 fi

--- a/lib/run-datadog.sh
+++ b/lib/run-datadog.sh
@@ -236,7 +236,9 @@ main() {
 }
 main "$@"
 
-while ! nc -z localhost 8126; do   
-  echo "Waiting for the trace agent to start on 8126..."
-  sleep 1
-done
+if [ "${WAIT_DD_TRACE_AGENT}" = "true" ]; then
+  while ! nc -z localhost 8126; do   
+    echo "Waiting for the trace agent to start on 8126..."
+    sleep 1
+  done
+fi

--- a/lib/run-datadog.sh
+++ b/lib/run-datadog.sh
@@ -233,19 +233,22 @@ main() {
       exec 9>&-
     fi
   fi
+  
+  # wait for the trace agent startup
+  if [ "${WAIT_DD_TRACE_AGENT}" = "true" ]; then
+    timeout=120
+    while ! nc -z localhost 8126 && [ $timeout -ge 0 ]; do
+      echo "Waiting for the trace agent to start on 8126..."
+      sleep 1
+      timeout=$((timeout - 1))
+    done
+    if [ $timeout -ge 0 ]; then
+        echo "Trace agent is listening for traces"
+    else
+        echo "Timed out waiting for the trace agent"
+    fi
+  fi
 }
 main "$@"
 
-timeout=120
-if [ "${WAIT_DD_TRACE_AGENT}" = "true" ]; then
-  while ! nc -z localhost 8126 && [ $timeout -ge 0 ]; do
-    echo "Waiting for the trace agent to start on 8126..."
-    sleep 1
-    timeout=$((timeout - 1))
-  done
-  if [ $timeout -ge 0 ]; then
-      echo "Trace agent is listening for traces"
-  else
-      echo "Timed out waiting for the trace agent"
-  fi
-fi
+


### PR DESCRIPTION
Adds an option `WAIT_DD_TRACE_AGENT` to enforce the supply script to wait for the trace agent port to open (i.e. ready to listen for traces). 

Closes  https://github.com/DataDog/datadog-cloudfoundry-buildpack/issues/117 