### PR TITLE
Standardize scripts structure

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -6,17 +6,17 @@ The main logic can be found in the shell scripts under the `lib` directory.
 
 ## Building
 
-To execute the `build` script, `dpkg` needs to be installed.
+To execute the `scripts/build.sh` script, `dpkg` needs to be installed.
 On macOS, `brew install dpkg`.
 
 Run the following command from the root of the repository to build the buildpack with the latest agent:
 ```bash
-REFRESH_ASSETS=1 ./build
+REFRESH_ASSETS=1 ./scripts/build.sh
 ```
 
 If you want to build for a specific version of the agent, specify the VERSION environment variable.
 ```bash
-VERSION=<AGENT_VERSION> REFRESH_ASSETS=1 ./build
+VERSION=<AGENT_VERSION> REFRESH_ASSETS=1 ./scripts/build.sh
 ```
 
 This produces a `datadog-cloudfoundry-buildpack.zip` file at the root of the repository that you can use directly with the CF CLI, or to build the [datadog-application-monitoring tile](https://github.com/DataDog/datadog-application-monitoring-pivotal-tile).

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,14 +9,18 @@ The main logic can be found in the shell scripts under the `lib` directory.
 To execute the `scripts/build.sh` script, `dpkg` needs to be installed.
 On macOS, `brew install dpkg`.
 
-Run the following command from the root of the repository to build the buildpack with the latest agent:
+
+If you want to build for a specific version of the agent, specify the VERSION environment variable when running the `prepare.sh` script.
+
 ```bash
-REFRESH_ASSETS=1 ./scripts/build.sh
+VERSION=<AGENT_VERSION> REFRESH_ASSETS=1 ./scripts/prepare.sh
 ```
 
-If you want to build for a specific version of the agent, specify the VERSION environment variable.
+
+Now, you can run the following command from the root of the repository to build the buildpack:
+
 ```bash
-VERSION=<AGENT_VERSION> REFRESH_ASSETS=1 ./scripts/build.sh
+VERSION=<BUILDPACK_VERSION> ./scripts/build.sh
 ```
 
-This produces a `datadog-cloudfoundry-buildpack.zip` file at the root of the repository that you can use directly with the CF CLI, or to build the [datadog-application-monitoring tile](https://github.com/DataDog/datadog-application-monitoring-pivotal-tile).
+This produces a `datadog-cloudfoundry-buildpack-<VERSION>.zip` file at the root of the repository that you can use directly with the CF CLI, or to build the [datadog-application-monitoring tile](https://github.com/DataDog/datadog-application-monitoring-pivotal-tile).

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,16 +2,22 @@
 
 set -euxo pipefail
 
-SRCDIR=$(pwd)
-
-NAME="datadog-cloudfoundry-buildpack"
-ZIPFILE="${NAME}.zip"
-
 main() {
-  rm -f ${ZIPFILE}
+  if [ -z "${VERSION}" ]; then
+    echo "VERSION is required to build the buildpack"
+    exit 0
+  fi
 
-  pushd ${SRCDIR}
-    zip -r "${ZIPFILE}" lib bin
+  srcDir=$(pwd)
+  name="datadog-cloudfoundry-buildpack"
+  zip="${name}-${VERSION}.zip"
+
+  echo "${VERSION}" > VERSION
+
+  rm -f ${zip}
+
+  pushd ${srcDir}
+    zip -r "${zip}" lib bin VERSION
   popd
 }
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+SRCDIR=$(pwd)
+
+NAME="datadog-cloudfoundry-buildpack"
+ZIPFILE="${NAME}.zip"
+
+main() {
+      rm -f ${ZIPFILE}
+
+  pushd ${SRCDIR}
+    zip -r "${ZIPFILE}" lib bin
+  popd
+}
+
+main "$@"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -8,7 +8,7 @@ NAME="datadog-cloudfoundry-buildpack"
 ZIPFILE="${NAME}.zip"
 
 main() {
-      rm -f ${ZIPFILE}
+  rm -f ${ZIPFILE}
 
   pushd ${SRCDIR}
     zip -r "${ZIPFILE}" lib bin

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -51,7 +51,7 @@ function download_dogstatsd() {
 }
 
 function cleanup() {
-  rm -rf ${TMPDIR}/*
+  rm -rf ${TMPDIR}
 }
 
 function main() {

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -1,42 +1,41 @@
-#!/bin/bash
-set -e
+#!/usr/bin/env bash
 
-SRCDIR=$(cd "$(dirname $0)/." && pwd)
-NAME="datadog-cloudfoundry-buildpack"
-ZIPFILE="${NAME}.zip"
+set -euxo pipefail
+
+SRCDIR=$(pwd)
+
 DOWNLOAD_BASE_URL="https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/datadog-"
 TRACEAGENT_DOWNLOAD_URL=${DOWNLOAD_BASE_URL}"agent_"
 IOT_AGENT_DOWNLOAD_URL=${DOWNLOAD_BASE_URL}"iot-agent_"
 DOGSTATSD_DOWNLOAD_URL=${DOWNLOAD_BASE_URL}"dogstatsd_"
 DOWNLOAD_URL_TAIL="-1_amd64.deb"
-AGENT_DEFAULT_VERSION="7.41.1"
 
-TMPDIR="${SRCDIR}/tmp"
+AGENT_DEFAULT_VERSION="7.41.1"
+VERSION=${VERSION:-${AGENT_DEFAULT_VERSION}}
+
+TMPDIR=$(mktemp -d)
+
 
 function download_trace_agent() {
   local trace_version="${1:-${AGENT_DEFAULT_VERSION}}"
   local trace_agent_download_url="${TRACEAGENT_DOWNLOAD_URL}${trace_version}${DOWNLOAD_URL_TAIL}"
 
-  mkdir -p ${TMPDIR}
-  curl -L ${trace_agent_download_url} -o ./tmp/datadog-agent.deb
+  curl -L ${trace_agent_download_url} -o $TMPDIR/datadog-agent.deb
   pushd ${TMPDIR}
     dpkg -x datadog-agent.deb .
   popd
   cp ${TMPDIR}/opt/datadog-agent/embedded/bin/trace-agent ${SRCDIR}/lib/trace-agent
-  rm -rf ${TMPDIR}/*
 }
 
 function download_iot_agent() {
   local iot_version="${1:-${AGENT_DEFAULT_VERSION}}"
   local iot_agent_download_url="${IOT_AGENT_DOWNLOAD_URL}${iot_version}${DOWNLOAD_URL_TAIL}"
 
-  mkdir -p ${TMPDIR}
-  curl -L ${iot_agent_download_url} -o ./tmp/datadog-agent.deb
+  curl -L ${iot_agent_download_url} -o $TMPDIR/datadog-agent.deb
   pushd ${TMPDIR}
     dpkg -x datadog-agent.deb .
   popd
   cp ${TMPDIR}/opt/datadog-agent/bin/agent/agent ${SRCDIR}/lib/agent
-  rm -rf ${TMPDIR}/*
 }
 
 function download_dogstatsd() {
@@ -44,24 +43,28 @@ function download_dogstatsd() {
   local dogstatsd_download_url="${DOGSTATSD_DOWNLOAD_URL}${dogstatsd_version}${DOWNLOAD_URL_TAIL}"
 
   mkdir -p ${TMPDIR}
-  curl -L ${dogstatsd_download_url} -o ./tmp/dogstatsd.deb
+  curl -L ${dogstatsd_download_url} -o $TMPDIR/dogstatsd.deb
   pushd ${TMPDIR}
     dpkg -x dogstatsd.deb .
   popd
   cp ${TMPDIR}/opt/datadog-dogstatsd/bin/dogstatsd ${SRCDIR}/lib/dogstatsd
+}
+
+function cleanup() {
   rm -rf ${TMPDIR}/*
 }
 
 function main() {
+  trap cleanup EXIT 
+
   if [ ! -f ${SRCDIR}/lib/dogstatsd ] || [ ! -f ${SRCDIR}/lib/trace-agent ]; then
     DOWNLOAD="true"
-  fi
-  if [ -n "${IOT_AGENT}" ] && [ ! -f ${SRCDIR}/lib/agent ]; then
+  elif [ ! -f ${SRCDIR}/lib/agent ]; then
+    DOWNLOAD="true"
+  elif [ -n "${REFRESH_ASSETS}" ]; then
     DOWNLOAD="true"
   fi
-  if [ -n "${REFRESH_ASSETS}" ]; then
-    DOWNLOAD="true"
-  fi
+
   if [ -n "${DOWNLOAD}" ]; then
     # Delete the old ones
     rm -f ${SRCDIR}/lib/agent
@@ -69,8 +72,6 @@ function main() {
     rm -f ${SRCDIR}/lib/trace-agent
 
     # Download the new ones
-    VERSION=${VERSION:-${AGENT_DEFAULT_VERSION}}
-
     download_trace_agent ${VERSION}
     chmod +x ${SRCDIR}/lib/trace-agent
 
@@ -80,14 +81,6 @@ function main() {
     download_dogstatsd ${VERSION}
     chmod +x ${SRCDIR}/lib/dogstatsd
   fi
-
-  rm -f ${ZIPFILE}
-
-  pushd ${SRCDIR}
-    if [ ! "${NO_ZIP}" ]; then
-      zip -r "${ZIPFILE}" lib bin
-    fi
-  popd
 }
 
 


### PR DESCRIPTION
Separate management scripts into `scripts/prepare.sh`, `scripts/build.sh` and `scripts/release.sh`.