### PR TITLE
Add `buildpack_version` tag

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -43,6 +43,8 @@ cp -r "${ROOT_DIR}/lib/test-endpoint.sh" "${BUILD_DIR}/.profile.d/00-test-endpoi
 cp "${ROOT_DIR}/lib/run-datadog.sh" "${BUILD_DIR}/.profile.d/01-run-datadog.sh"
 cp "${ROOT_DIR}/lib/redirect-logs.sh" "${BUILD_DIR}/.profile.d/02-redirect-logs.sh"
 
+cp "${ROOT_DIR}/VERSION" "${DATADOG_DIR}/VERSION"
+
 if [ -f "${DATADOG_DIR}/agent" ]; then
   chmod +x "${DATADOG_DIR}/agent"
 fi

--- a/bin/supply
+++ b/bin/supply
@@ -44,6 +44,8 @@ cp -r "${ROOT_DIR}/lib/test-endpoint.sh" "${BUILD_DIR}/.profile.d/00-test-endpoi
 cp "${ROOT_DIR}/lib/run-datadog.sh" "${BUILD_DIR}/.profile.d/01-run-datadog.sh"
 cp "${ROOT_DIR}/lib/redirect-logs.sh" "${BUILD_DIR}/.profile.d/02-redirect-logs.sh"
 
+cp "${ROOT_DIR}/VERSION" "${DATADOG_DIR}/VERSION"
+
 if [ -f "${DATADOG_DIR}/agent" ]; then
   chmod +x "${DATADOG_DIR}/agent"
 fi

--- a/lib/scripts/get_tags.py
+++ b/lib/scripts/get_tags.py
@@ -70,6 +70,12 @@ if user_tags:
     except Exception as e:
         print("there was an issue parsing the tags in DD_TAGS: {}".format(e))
 
+version_file = "/home/vcap/app/.datadog/VERSION"
+if os.path.exists(version_file):
+        with open(version_file, 'r') as file:
+            buildpack_version = file.read().rstrip()
+            tags.append("buildpack_version:{}".format(buildpack_version))
+
 tags = [ tag.replace(" ", "_") for tag in tags ]
 tags = list(dict.fromkeys(tags))
 


### PR DESCRIPTION
Add a `buildpack_version` tag to traces, logs and metrics.