### PR TITLE
Fix `buildpack_version` tag in the update_tags script

### DIFF
--- a/lib/scripts/update_tags.rb
+++ b/lib/scripts/update_tags.rb
@@ -38,7 +38,7 @@ if ! DD_TAGS.empty?
 end
 
 if File.exists?(version_file)
-    tags.concat("buildpack_version:" + File.read(version_file).strip)
+    tags.push("buildpack_version:" + File.read(version_file).strip)
 end
 
 # if the script is executed during the warmup period, merge incoming tags with the existing tags


### PR DESCRIPTION
We're appending a string to a list, we need to use [push](https://ruby-doc.org/core-2.5.0/Array.html#method-i-push) instead of [concat](https://ruby-doc.org/core-2.5.0/Array.html#method-i-concat).

Error:

```ruby
Traceback (most recent call last):
	1: from update_tags.rb:41:in `<main>'
update_tags.rb:41:in `concat': no implicit conversion of String into Array (TypeError)
```