### PR TITLE
Revert #163 + Fix `container_name` missing tag

### DIFF
--- a/lib/run-datadog.sh
+++ b/lib/run-datadog.sh
@@ -18,7 +18,7 @@ export DD_DOGSTATSD_TAGS
 source "${DATADOG_DIR}/scripts/utils.sh"
 
 setup_datadog() {
-  pushd "${DATADOG_DIR}" >/dev/null
+  pushd "${DATADOG_DIR}"
 
     export DD_LOG_FILE="${DATADOG_DIR}/dogstatsd.log"
     export DD_API_KEY
@@ -113,7 +113,7 @@ setup_datadog() {
       export DD_LOG_FILE=${DATADOG_DIR}/dogstatsd.log
       sed -i "s~log_file: AGENT_LOG_FILE~log_file: ${DD_LOG_FILE}~" dist/datadog.yaml
     fi
-  popd >/dev/null
+  popd
 }
 
 start_datadog() {
@@ -122,7 +122,7 @@ start_datadog() {
   export DD_TAGS
   DD_DOGSTATSD_TAGS=$(python "${DATADOG_DIR}"/scripts/get_tags.py)
   export DD_DOGSTATSD_TAGS
-  pushd "${DATADOG_DIR}" >/dev/null
+  pushd "${DATADOG_DIR}"
     export DD_LOG_FILE="${DATADOG_DIR}/dogstatsd.log"
     export DD_API_KEY
     export DD_DD_URL
@@ -152,7 +152,7 @@ start_datadog() {
         export DD_LOG_FILE=agent.log
         export DD_IOT_HOST=false
 
-        echo "Starting datadog agent"
+        echo "Starting Datadog agent"
         if [ "${SUPPRESS_DD_AGENT_OUTPUT}" = "true" ]; then
           ./agent run --cfgpath dist/ --pidfile run/agent.pid > /dev/null 2>&1 &
         else
@@ -178,13 +178,13 @@ start_datadog() {
       fi
       FIRST_RUN=false
     fi
-  popd >/dev/null
+  popd
 }
 
 stop_datadog() {
-  pushd "${DATADOG_DIR}" >/dev/null
+  pushd "${DATADOG_DIR}"
     if check_if_running "${AGENT_PIDFILE}" "${AGENT_CMD}"; then
-      echo "Stopping datadog agent process, pid: $(cat "${AGENT_PIDFILE}")"
+      echo "Stopping agent process, pid: $(cat "${AGENT_PIDFILE}")"
       # first try to stop the agent so we don't lose data and then force it
       (./agent stop --cfgpath dist/) || true
       find_pid_kill_and_wait "${AGENT_CMD}" "${AGENT_PIDFILE}" 5 1 || true
@@ -198,7 +198,7 @@ stop_datadog() {
       find_pid_kill_and_wait "${DOGSTATSD_CMD}" "${DOGSTATSD_PIDFILE}" 5 1
       rm -f "${DOGSTATSD_PIDFILE}"
     fi
-  popd >/dev/null
+  popd
 }
 
 monit_datadog() {
@@ -249,6 +249,6 @@ main() {
     fi
   fi
 }
+main "$@"
 
-main "$@" 2>&1 | tee -a "${DATADOG_DIR}/run-datadog.log"
 

--- a/lib/scripts/check_datadog.sh
+++ b/lib/scripts/check_datadog.sh
@@ -33,4 +33,4 @@ main() {
     check_datadog
 }
 
-main "$@" 2>&1 | tee -a "${DATADOG_DIR}/check_datadog.log"
+main "$@"

--- a/lib/scripts/update_tags.rb
+++ b/lib/scripts/update_tags.rb
@@ -34,7 +34,7 @@ if ! DD_NODE_AGENT_TAGS.empty?
 end
 
 if ! DD_TAGS.empty?
-    tags.concat(sanitize(DD_TAGS, " "))
+    tags.concat(sanitize(DD_TAGS, ","))
 end
 
 if File.exists?(version_file)

--- a/lib/scripts/utils.sh
+++ b/lib/scripts/utils.sh
@@ -216,7 +216,7 @@ redirect() {
             \"title\": \"Resetting buildpack log redirection\",
             \"text\": \"TCP socket on port ${STD_LOG_COLLECTION_PORT} for log redirection closed. Restarting it.\",
             \"priority\": \"normal\",
-            \"tags\": $(python ${DATADOG_DIR}/scripts/get_tags.py),
+            \"tags\": $(LEGACY_TAGS_FORMAT=true python ${DATADOG_DIR}/scripts/get_tags.py),
             \"alert_type\": \"info\"
       }" "${DD_API_SITE}v1/events?api_key=${DD_API_KEY}"
     fi


### PR DESCRIPTION
Fixing several regressions in master resulting in missing tags and crashing sidecar processes:
- Revert PR #163
- Fix DD_TAGS split by space to by comma in the update_tags script causing missing container_name tag