### PR TITLE
Fix missing tags in extra logs sources

### DIFF
--- a/lib/scripts/create_logs_config.rb
+++ b/lib/scripts/create_logs_config.rb
@@ -47,9 +47,9 @@ if !logs_config.nil?
 
   if !tags_list.empty?
     tags_list = tags_list.uniq
-    config["logs"][0]["tags"] = tags_list
+    config["logs"].each { |conf| conf["tags"] = tags_list }
   end
-  
+
 else
   puts "ERROR: `LOGS_CONFIG` must be set in order to collect logs. For more info, see: https://github.com/DataDog/datadog-cloudfoundry-buildpack#log-collection"
   exit(1)


### PR DESCRIPTION
Fixes the `lib/scripts/create_logs_config.rb` script to attach tags to all the entries in the `LOGS_CONFIG`.

Closes #173 
