### PR TITLE
Fix release script to pick up the new VERSION

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -11,10 +11,10 @@ DRY_RUN=${DRY_RUN:-"true"}
 RELEASE_BUCKET=${RELEASE_BUCKET:-"false"}
 REPO_BRANCH=${REPO_BRANCH:-"master"}
 
+git checkout $REPO_BRANCH
 
 VERSION=$(cat VERSION)
 
-git checkout $REPO_BRANCH
 
 echo "Preparing the buildpack"
 REFRESH_ASSETS=1 ./scripts/prepare.sh


### PR DESCRIPTION
The `VERSION` environment variable should take the value from the `VERSION` file *after* checking out the target branch, not before.