### PR TITLE
Fix `apm_config.receiver_socket` default path

### DIFF
--- a/lib/dist/datadog.yaml
+++ b/lib/dist/datadog.yaml
@@ -202,6 +202,7 @@ apm_config:
   #   Whether or not the APM Agent should run
   enabled: true
   log_file: TRACE_LOG_FILE
+  receiver_socket: "/home/app/.datadog/run/apm.socket"
 #   The environment tag that Traces should be tagged with
 #   Will inherit from "env" tag if none is applied here
 #   env: none


### PR DESCRIPTION
### What does this PR do?

Fixes the value of the `apm_config.receiver_socket` to be the correct `run` directory we use in cloud foundry.

<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->
