### PR TITLE
Fix logs_config validation for agent 7.65+

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ env:
   # Redirect Container Stdout/Stderr to a local port so the agent can collect the logs
   STD_LOG_COLLECTION_PORT: <PORT>
   # Configure the agent to collect logs from the wanted port and set the value for source and service
-  LOGS_CONFIG: '[{"type":"tcp","port":"<PORT>","source":"<SOURCE>","service":"<SERVICE>"}]'
+  LOGS_CONFIG: '[{"type":"tcp","port": <PORT>,"source":"<SOURCE>","service":"<SERVICE>"}]'
 ```
 
 **Configure log collection**
@@ -134,7 +134,7 @@ env:
   DD_LOGS_ENABLED: true
   DD_ENABLE_CHECKS: false
   STD_LOG_COLLECTION_PORT: 10514
-  LOGS_CONFIG: '[{"type":"tcp","port":"10514","source":"java","service":"app01"}]'
+  LOGS_CONFIG: '[{"type":"tcp","port": 10514,"source":"java","service":"app01"}]'
 ```
 
 ### Unified Service Tagging

--- a/lib/scripts/create_logs_config.rb
+++ b/lib/scripts/create_logs_config.rb
@@ -30,6 +30,9 @@ end
 
 if !logs_config.nil?
   config["logs"] = JSON.parse(logs_config)
+  
+  # convert every port field in every config in config["logs"] to an int
+  config["logs"].each { |conf| conf["port"] = conf["port"].to_i }
 
   tags_list = []
 


### PR DESCRIPTION
### What does this PR do?
<!-- 

What inspired you to submit this pull request?
Link to the issue describing the bug that you're fixing.

If there is not yet an issue for your bug, please open a new issue and then link to that issue in your pull request.
Note: In some cases, one person's "bug" is another person's "feature." If the pull request does not address an existing issue with the "bug" label, the maintainers have the final say on whether the current behavior is a bug.

-->

- Fixes the logs config behavior to support datadog-agent 7.65.0+ which added logs_config validation and would fail if the `port` field is a string.

### Description of the Change


- Updates the README to specify that the `port` field in the `LOGS_CONFIG` should be a int.
- Update the `create_logs_config.rb` script to automatically convert the `port` field to an int when generating the logs config file.


<!--

A brief description of the change being made with this pull request. 

We must be able to understand the design of your change from this description. 
If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. 
Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (including scripts, commands you ran, etc.), and describe the results you observed.

-->

### Additional Notes

<!-- Anything else we should know when reviewing? -->

### Release Notes

<!--

If the PR title is not enough to describe the changes in a single line that explains this improvement in
terms that a user can understand. This text will be added in release notes.

For example, you can provide additionnal notes about feature deprecation or backward incompatible changes.

-->

### Review checklist (to be filled by reviewers)

- [ ] PR title must be written as a CHANGELOG entry [(see why)](/CONTRIBUTING.md#pull-request-title)
- [ ] Files changes must correspond to the primary purpose of the PR as described in the title (small unrelated changes should have their own PR)
- [ ] PR must have one `changelog/` label attached. If applicable it should have the `backward-incompatible` label attached.
- [ ] PR should not have `do-not-merge/` label attached.
- [ ] If Applicable, issue must have `kind/` and `severity/` labels attached at least.
