### PR TITLE
Add build script and pin versions for Node.js sample app

### DIFF
--- a/examples/cf-nodejs-sample-app/build.sh
+++ b/examples/cf-nodejs-sample-app/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -euo pipefail
+
+npm ci

--- a/examples/cf-nodejs-sample-app/package.json
+++ b/examples/cf-nodejs-sample-app/package.json
@@ -16,6 +16,10 @@
     "url": "https://github.com/DataDog/cf-nodejs-sample-app/issues"
   },
   "homepage": "https://github.com/DataDog/cf-nodejs-sample-app#readme",
+  "engines": {
+    "node": "20.x",
+    "npm": "10.x"
+  },
   "dependencies": {
     "dd-trace": "^5.0.0",
     "hot-shots": "^10.0.0"


### PR DESCRIPTION
- Add `build.sh` to vendor `node_modules` via `npm ci`
- Pin Node.js 20.x and npm 10.x in `package.json`