### PR TITLE
Add PHP sample app with APM tracing and profiling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,4 @@ examples/*/node_modules/
 examples/*/.bundle/
 examples/cf-go-sample-app/main
 examples/cf-java-sample-app/target/
-examples/cf-php-sample-app/extensions/
+examples/*/extensions/

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ examples/*/node_modules/
 examples/*/.bundle/
 examples/cf-go-sample-app/main
 examples/cf-java-sample-app/target/
+examples/cf-php-sample-app/extensions/

--- a/examples/cf-php-sample-app/.bp-config/options.json
+++ b/examples/cf-php-sample-app/.bp-config/options.json
@@ -1,5 +1,5 @@
 {
-    "WEB_SERVER": "php-server",
+    "WEB_SERVER": "httpd",
     "PHP_VERSION": "{PHP_82_LATEST}",
     "WEBDIR": "htdocs"
 }

--- a/examples/cf-php-sample-app/.bp-config/options.json
+++ b/examples/cf-php-sample-app/.bp-config/options.json
@@ -1,0 +1,6 @@
+{
+    "WEB_SERVER": "php-server",
+    "PHP_VERSION": "{PHP_82_LATEST}",
+    "PHP_EXTENSIONS": ["curl", "openssl"],
+    "WEBDIR": "htdocs"
+}

--- a/examples/cf-php-sample-app/.bp-config/options.json
+++ b/examples/cf-php-sample-app/.bp-config/options.json
@@ -1,6 +1,5 @@
 {
     "WEB_SERVER": "php-server",
     "PHP_VERSION": "{PHP_82_LATEST}",
-    "PHP_EXTENSIONS": ["curl", "openssl"],
     "WEBDIR": "htdocs"
 }

--- a/examples/cf-php-sample-app/.bp-config/php/php.ini.d/datadog.ini
+++ b/examples/cf-php-sample-app/.bp-config/php/php.ini.d/datadog.ini
@@ -1,0 +1,3 @@
+extension=/home/vcap/app/extensions/dd-library-php/trace/ext/20220829/ddtrace.so
+extension=/home/vcap/app/extensions/dd-library-php/profiling/ext/20220829/datadog-profiling.so
+datadog.trace.sources_path=/home/vcap/app/extensions/dd-library-php/trace/src

--- a/examples/cf-php-sample-app/.bp-config/php/php.ini.d/datadog.ini
+++ b/examples/cf-php-sample-app/.bp-config/php/php.ini.d/datadog.ini
@@ -1,3 +1,0 @@
-extension=/home/vcap/app/extensions/dd-library-php/trace/ext/20220829/ddtrace.so
-extension=/home/vcap/app/extensions/dd-library-php/profiling/ext/20220829/datadog-profiling.so
-datadog.trace.sources_path=/home/vcap/app/extensions/dd-library-php/trace/src

--- a/examples/cf-php-sample-app/README.md
+++ b/examples/cf-php-sample-app/README.md
@@ -1,0 +1,9 @@
+# A sample Cloud Foundry App in PHP
+
+This App is an example of how to use the [Datadog Cloud Foundry Buildpack](https://github.com/datadog/datadog-cloudfoundry-buildpack) to instrument a PHP application with APM tracing and continuous profiling.
+
+## How to build and push
+
+1. Run `./build.sh` to vendor Composer dependencies into a local `vendor/` folder and to download the `dd-trace-php` native extensions into `extensions/` so the app can be staged on offline Cloud Foundry environments.
+2. Update the `manifest.yml` file with any other extra configuration options.
+3. Run `cf push --var DD_API_KEY=<API_KEY> --var ENV=<ENV_NAME>`, substituting `<API_KEY>` with your Datadog API key value.

--- a/examples/cf-php-sample-app/README.md
+++ b/examples/cf-php-sample-app/README.md
@@ -4,6 +4,6 @@ This App is an example of how to use the [Datadog Cloud Foundry Buildpack](https
 
 ## How to build and push
 
-1. Run `./build.sh` to vendor Composer dependencies into a local `vendor/` folder and to download the `dd-trace-php` native extensions into `extensions/` so the app can be staged on offline Cloud Foundry environments.
+1. Run `./build.sh` to vendor Composer dependencies into a local `vendor/` folder so the app can be staged on offline Cloud Foundry environments. The `dd-trace-php` native extensions are provided by the Datadog buildpack itself once `DD_APM_INSTRUMENTATION_ENABLED=true` is set.
 2. Update the `manifest.yml` file with any other extra configuration options.
 3. Run `cf push --var DD_API_KEY=<API_KEY> --var ENV=<ENV_NAME>`, substituting `<API_KEY>` with your Datadog API key value.

--- a/examples/cf-php-sample-app/build.sh
+++ b/examples/cf-php-sample-app/build.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+# Vendor Composer dependencies and the dd-trace-php native extensions for
+# the Cloud Foundry Linux stack so the app can stage on offline environments
+# where the buildpack cannot reach packagist.org or github.com.
+DD_TRACE_PHP_VERSION="1.19.1"
+PHP_API="20220829" # PHP 8.2 ABI tag
+
+rm -rf vendor extensions
+composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader
+
+mkdir -p extensions
+TARBALL="dd-library-php-${DD_TRACE_PHP_VERSION}-x86_64-linux-gnu-${PHP_API}.tar.gz"
+curl -fsSL -o "$TARBALL" \
+    "https://github.com/DataDog/dd-trace-php/releases/download/${DD_TRACE_PHP_VERSION}/${TARBALL}"
+tar -xzf "$TARBALL" -C extensions \
+    --exclude='dd-library-php/appsec'
+rm -f "$TARBALL"

--- a/examples/cf-php-sample-app/build.sh
+++ b/examples/cf-php-sample-app/build.sh
@@ -1,19 +1,11 @@
 #!/bin/bash
 set -euo pipefail
 
-# Vendor Composer dependencies and the dd-trace-php native extensions for
-# the Cloud Foundry Linux stack so the app can stage on offline environments
-# where the buildpack cannot reach packagist.org or github.com.
-DD_TRACE_PHP_VERSION="1.19.1"
-PHP_API="20220829" # PHP 8.2 ABI tag
+# Vendor Composer dependencies for the Cloud Foundry Linux stack so the app
+# can stage on offline environments where the buildpack cannot reach
+# packagist.org. The dd-trace-php native extensions are provided by the
+# Datadog Cloud Foundry buildpack itself when DD_APM_INSTRUMENTATION_ENABLED
+# is set.
 
-rm -rf vendor extensions
+rm -rf vendor
 composer install --no-dev --no-interaction --prefer-dist --optimize-autoloader
-
-mkdir -p extensions
-TARBALL="dd-library-php-${DD_TRACE_PHP_VERSION}-x86_64-linux-gnu-${PHP_API}.tar.gz"
-curl -fsSL -o "$TARBALL" \
-    "https://github.com/DataDog/dd-trace-php/releases/download/${DD_TRACE_PHP_VERSION}/${TARBALL}"
-tar -xzf "$TARBALL" -C extensions \
-    --exclude='dd-library-php/appsec'
-rm -f "$TARBALL"

--- a/examples/cf-php-sample-app/composer.json
+++ b/examples/cf-php-sample-app/composer.json
@@ -1,0 +1,14 @@
+{
+    "require": {
+        "php": "^8.2",
+        "slim/slim": "^4.12",
+        "slim/psr7": "^1.6",
+        "datadog/php-datadogstatsd": "^1.5"
+    },
+    "config": {
+        "platform": {
+            "php": "8.2"
+        },
+        "sort-packages": true
+    }
+}

--- a/examples/cf-php-sample-app/composer.json
+++ b/examples/cf-php-sample-app/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "php": "^8.2",
+        "php": "8.2.*",
         "slim/slim": "^4.12",
         "slim/psr7": "^1.6",
         "datadog/php-datadogstatsd": "^1.5"

--- a/examples/cf-php-sample-app/composer.json
+++ b/examples/cf-php-sample-app/composer.json
@@ -7,7 +7,8 @@
     },
     "config": {
         "platform": {
-            "php": "8.2"
+            "php": "8.2",
+            "ext-sockets": "8.2"
         },
         "sort-packages": true
     }

--- a/examples/cf-php-sample-app/composer.lock
+++ b/examples/cf-php-sample-app/composer.lock
@@ -1,0 +1,759 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "edad87add9c98e1c8e50239f61d8c89c",
+    "packages": [
+        {
+            "name": "datadog/php-datadogstatsd",
+            "version": "1.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/DataDog/php-datadogstatsd.git",
+                "reference": "f0d61f11e01780ef7d96daed9781c7db9311a568"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DataDog/php-datadogstatsd/zipball/f0d61f11e01780ef7d96daed9781c7db9311a568",
+                "reference": "f0d61f11e01780ef7d96daed9781c7db9311a568",
+                "shasum": ""
+            },
+            "require": {
+                "ext-sockets": "*",
+                "php": ">=5.6.0"
+            },
+            "require-dev": {
+                "mikey179/vfsstream": "^1.6",
+                "squizlabs/php_codesniffer": "^3.3",
+                "yoast/phpunit-polyfills": "^1.0.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DataDog\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alex Corley",
+                    "email": "anthroprose@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Datadog",
+                    "email": "dev@datadoghq.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "An extremely simple PHP datadogstatsd client",
+            "homepage": "https://www.datadoghq.com/",
+            "keywords": [
+                "DataDog",
+                "check",
+                "error-reporting",
+                "health",
+                "logging",
+                "monitoring",
+                "statsd"
+            ],
+            "support": {
+                "chat": "https://chat.datadoghq.com/",
+                "email": "package@datadoghq.com",
+                "irc": "irc://irc.freenode.net/datadog",
+                "issues": "https://github.com/DataDog/php-datadogstatsd/issues",
+                "source": "https://github.com/DataDog/php-datadogstatsd"
+            },
+            "time": "2025-08-25T15:42:11+00:00"
+        },
+        {
+            "name": "fig/http-message-util",
+            "version": "1.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message-util.git",
+                "reference": "9d94dc0154230ac39e5bf89398b324a86f63f765"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message-util/zipball/9d94dc0154230ac39e5bf89398b324a86f63f765",
+                "reference": "9d94dc0154230ac39e5bf89398b324a86f63f765",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3 || ^7.0 || ^8.0"
+            },
+            "suggest": {
+                "psr/http-message": "The package containing the PSR-7 interfaces"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Fig\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Utility classes and constants for use with PSR-7 (psr/http-message)",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/http-message-util/issues",
+                "source": "https://github.com/php-fig/http-message-util/tree/1.1.5"
+            },
+            "time": "2020-11-24T22:02:12+00:00"
+        },
+        {
+            "name": "nikic/fast-route",
+            "version": "v1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/FastRoute.git",
+                "reference": "181d480e08d9476e61381e04a71b34dc0432e812"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/FastRoute/zipball/181d480e08d9476e61381e04a71b34dc0432e812",
+                "reference": "181d480e08d9476e61381e04a71b34dc0432e812",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35|~5.7"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php"
+                ],
+                "psr-4": {
+                    "FastRoute\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov",
+                    "email": "nikic@php.net"
+                }
+            ],
+            "description": "Fast request router for PHP",
+            "keywords": [
+                "router",
+                "routing"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/FastRoute/issues",
+                "source": "https://github.com/nikic/FastRoute/tree/master"
+            },
+            "time": "2018-02-13T20:26:39+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
+            },
+            "time": "2021-11-05T16:47:00+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "reference": "2b4765fddfe3b508ac62f829e852b1501d3f6e8a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "PSR-17: Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory"
+            },
+            "time": "2024-04-15T12:06:14+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
+            "name": "psr/http-server-handler",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-server-handler.git",
+                "reference": "84c4fb66179be4caaf8e97bd239203245302e7d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-server-handler/zipball/84c4fb66179be4caaf8e97bd239203245302e7d4",
+                "reference": "84c4fb66179be4caaf8e97bd239203245302e7d4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP server-side request handler",
+            "keywords": [
+                "handler",
+                "http",
+                "http-interop",
+                "psr",
+                "psr-15",
+                "psr-7",
+                "request",
+                "response",
+                "server"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-server-handler/tree/1.0.2"
+            },
+            "time": "2023-04-10T20:06:20+00:00"
+        },
+        {
+            "name": "psr/http-server-middleware",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-server-middleware.git",
+                "reference": "c1481f747daaa6a0782775cd6a8c26a1bf4a3829"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-server-middleware/zipball/c1481f747daaa6a0782775cd6a8c26a1bf4a3829",
+                "reference": "c1481f747daaa6a0782775cd6a8c26a1bf4a3829",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "psr/http-message": "^1.0 || ^2.0",
+                "psr/http-server-handler": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP server-side middleware",
+            "keywords": [
+                "http",
+                "http-interop",
+                "middleware",
+                "psr",
+                "psr-15",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/http-server-middleware/issues",
+                "source": "https://github.com/php-fig/http-server-middleware/tree/1.0.2"
+            },
+            "time": "2023-04-11T06:14:47+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
+            },
+            "time": "2024-09-11T13:17:53+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "support": {
+                "issues": "https://github.com/ralouphie/getallheaders/issues",
+                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
+            },
+            "time": "2019-03-08T08:55:37+00:00"
+        },
+        {
+            "name": "slim/psr7",
+            "version": "1.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slimphp/Slim-Psr7.git",
+                "reference": "76e7e3b1cdfd583e9035c4c966c08e01e45ce959"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slimphp/Slim-Psr7/zipball/76e7e3b1cdfd583e9035c4c966c08e01e45ce959",
+                "reference": "76e7e3b1cdfd583e9035c4c966c08e01e45ce959",
+                "shasum": ""
+            },
+            "require": {
+                "fig/http-message-util": "^1.1.5",
+                "php": "^8.0",
+                "psr/http-factory": "^1.1",
+                "psr/http-message": "^1.0 || ^2.0",
+                "ralouphie/getallheaders": "^3.0"
+            },
+            "provide": {
+                "psr/http-factory-implementation": "^1.0",
+                "psr/http-message-implementation": "^1.0 || ^2.0"
+            },
+            "require-dev": {
+                "adriansuter/php-autoload-override": "^1.5|| ^2.0",
+                "ext-json": "*",
+                "http-interop/http-factory-tests": "^1.0 || ^2.0",
+                "php-http/psr7-integration-tests": "^1.5",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^9.6 || ^10",
+                "squizlabs/php_codesniffer": "^3.13"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Slim\\Psr7\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Josh Lockhart",
+                    "email": "hello@joshlockhart.com",
+                    "homepage": "https://joshlockhart.com"
+                },
+                {
+                    "name": "Andrew Smith",
+                    "email": "a.smith@silentworks.co.uk",
+                    "homepage": "https://silentworks.co.uk"
+                },
+                {
+                    "name": "Rob Allen",
+                    "email": "rob@akrabat.com",
+                    "homepage": "https://akrabat.com"
+                },
+                {
+                    "name": "Pierre Berube",
+                    "email": "pierre@lgse.com",
+                    "homepage": "https://www.lgse.com"
+                }
+            ],
+            "description": "Strict PSR-7 implementation",
+            "homepage": "https://www.slimframework.com",
+            "keywords": [
+                "http",
+                "psr-7",
+                "psr7"
+            ],
+            "support": {
+                "issues": "https://github.com/slimphp/Slim-Psr7/issues",
+                "source": "https://github.com/slimphp/Slim-Psr7/tree/1.8.0"
+            },
+            "time": "2025-11-02T17:51:19+00:00"
+        },
+        {
+            "name": "slim/slim",
+            "version": "4.15.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/slimphp/Slim.git",
+                "reference": "887893516557506f254d950425ce7f5387a26970"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/slimphp/Slim/zipball/887893516557506f254d950425ce7f5387a26970",
+                "reference": "887893516557506f254d950425ce7f5387a26970",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "nikic/fast-route": "^1.3",
+                "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "psr/container": "^1.0 || ^2.0",
+                "psr/http-factory": "^1.1",
+                "psr/http-message": "^1.1 || ^2.0",
+                "psr/http-server-handler": "^1.0",
+                "psr/http-server-middleware": "^1.0",
+                "psr/log": "^1.1 || ^2.0 || ^3.0"
+            },
+            "require-dev": {
+                "adriansuter/php-autoload-override": "^1.4 || ^2",
+                "ext-simplexml": "*",
+                "guzzlehttp/psr7": "^2.6",
+                "httpsoft/http-message": "^1.1",
+                "httpsoft/http-server-request": "^1.1",
+                "laminas/laminas-diactoros": "^2.17 || ^3",
+                "nyholm/psr7": "^1.8",
+                "nyholm/psr7-server": "^1.1",
+                "phpspec/prophecy": "^1.19",
+                "phpspec/prophecy-phpunit": "^2.1",
+                "phpstan/phpstan": "^1 || ^2",
+                "phpunit/phpunit": "^9.6 || ^10 || ^11 || ^12",
+                "slim/http": "^1.3",
+                "slim/psr7": "^1.6",
+                "squizlabs/php_codesniffer": "^3.10",
+                "vimeo/psalm": "^5 || ^6"
+            },
+            "suggest": {
+                "ext-simplexml": "Needed to support XML format in BodyParsingMiddleware",
+                "ext-xml": "Needed to support XML format in BodyParsingMiddleware",
+                "php-di/php-di": "PHP-DI is the recommended container library to be used with Slim",
+                "slim/psr7": "Slim PSR-7 implementation. See https://www.slimframework.com/docs/v4/start/installation.html for more information."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Slim\\": "Slim"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Josh Lockhart",
+                    "email": "hello@joshlockhart.com",
+                    "homepage": "https://joshlockhart.com"
+                },
+                {
+                    "name": "Andrew Smith",
+                    "email": "a.smith@silentworks.co.uk",
+                    "homepage": "https://silentworks.co.uk"
+                },
+                {
+                    "name": "Rob Allen",
+                    "email": "rob@akrabat.com",
+                    "homepage": "https://akrabat.com"
+                },
+                {
+                    "name": "Pierre Berube",
+                    "email": "pierre@lgse.com",
+                    "homepage": "https://www.lgse.com"
+                },
+                {
+                    "name": "Gabriel Manricks",
+                    "email": "gmanricks@me.com",
+                    "homepage": "http://gabrielmanricks.com"
+                }
+            ],
+            "description": "Slim is a PHP micro framework that helps you quickly write simple yet powerful web applications and APIs",
+            "homepage": "https://www.slimframework.com",
+            "keywords": [
+                "api",
+                "framework",
+                "micro",
+                "router"
+            ],
+            "support": {
+                "docs": "https://www.slimframework.com/docs/v4/",
+                "forum": "https://discourse.slimframework.com/",
+                "irc": "irc://irc.freenode.net:6667/slimphp",
+                "issues": "https://github.com/slimphp/Slim/issues",
+                "rss": "https://www.slimframework.com/blog/feed.rss",
+                "slack": "https://slimphp.slack.com/",
+                "source": "https://github.com/slimphp/Slim",
+                "wiki": "https://github.com/slimphp/Slim/wiki"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/slimphp",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slim/slim",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-11-21T12:23:44+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "^8.2"
+    },
+    "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.2",
+        "ext-sockets": "8.2"
+    },
+    "plugin-api-version": "2.9.0"
+}

--- a/examples/cf-php-sample-app/composer.lock
+++ b/examples/cf-php-sample-app/composer.lock
@@ -748,7 +748,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.2"
+        "php": "8.2.*"
     },
     "platform-dev": {},
     "platform-overrides": {

--- a/examples/cf-php-sample-app/htdocs/index.php
+++ b/examples/cf-php-sample-app/htdocs/index.php
@@ -1,0 +1,19 @@
+<?php
+require __DIR__ . '/../vendor/autoload.php';
+
+use Slim\Factory\AppFactory;
+use DataDog\DogStatsd;
+
+$statsd = new DogStatsd(['host' => '127.0.0.1', 'port' => 8125]);
+
+$app = AppFactory::create();
+
+$app->get('/', function ($request, $response) use ($statsd) {
+    error_log('HELLO WORLD!');
+    $statsd->increment('pcf.testing.custom_metrics.incr', 1, ['boo:baz', 'pcf']);
+    $statsd->decrement('pcf.testing.custom_metrics.decr', 1, ['foo:bar', 'pcf']);
+    $response->getBody()->write('Hello World from PHP!');
+    return $response;
+});
+
+$app->run();

--- a/examples/cf-php-sample-app/manifest.yml
+++ b/examples/cf-php-sample-app/manifest.yml
@@ -1,0 +1,34 @@
+---
+applications:
+  - name: php-sample-app
+    memory: 256M
+    instances: 1
+    path: .
+    buildpacks:
+      - datadog_application_monitoring
+      - php_buildpack
+    env:
+      DD_API_KEY: ((DD_API_KEY))
+      DD_VERSION: '1.0.0'
+      DD_SERVICE: 'php-sample-app'
+      DD_ENV: pcf-((ENV))
+      DD_LOGS_ENABLED: true
+      STD_LOG_COLLECTION_PORT: 10514
+      LOGS_CONFIG: '[{"type":"tcp","port":"10514","source":"php","service":"php-sample-app"}]'
+      DD_PROFILING_ENABLED: 'true'
+      DD_TRACE_ENABLED: 'true'
+      DD_ENABLE_CAPI_METADATA_COLLECTION: 'true'
+      TEST[KEY]: VALUE
+    metadata:
+      labels:
+        tags.datadoghq.com/service: php-sample-app
+        tags.datadoghq.com/env: pcf-((ENV))
+        tags.datadoghq.com/version: 1.0.0
+        tags.datadoghq.com/metadata_key: metadata_value
+        tags.datadoghq.com/label_key: label_value
+        tags.datadoghq.com/foo: bar
+    sidecars:
+      - name: traffic_generator
+        process_types:
+          - web
+        command: './traffic'

--- a/examples/cf-php-sample-app/manifest.yml
+++ b/examples/cf-php-sample-app/manifest.yml
@@ -2,6 +2,7 @@
 applications:
   - name: php-sample-app
     memory: 1024M
+    disk_quota: 2048M
     instances: 1
     path: .
     command: $HOME/php/bin/php -S 0.0.0.0:$PORT -t htdocs

--- a/examples/cf-php-sample-app/manifest.yml
+++ b/examples/cf-php-sample-app/manifest.yml
@@ -5,7 +5,6 @@ applications:
     disk_quota: 2048M
     instances: 1
     path: .
-    command: $HOME/php/bin/php -S 0.0.0.0:$PORT -t htdocs
     buildpacks:
       - datadog_application_monitoring
       - php_buildpack

--- a/examples/cf-php-sample-app/manifest.yml
+++ b/examples/cf-php-sample-app/manifest.yml
@@ -4,6 +4,7 @@ applications:
     memory: 256M
     instances: 1
     path: .
+    command: $HOME/php/bin/php -S 0.0.0.0:$PORT -t htdocs
     buildpacks:
       - datadog_application_monitoring
       - php_buildpack
@@ -16,7 +17,6 @@ applications:
       STD_LOG_COLLECTION_PORT: 10514
       LOGS_CONFIG: '[{"type":"tcp","port":"10514","source":"php","service":"php-sample-app"}]'
       DD_PROFILING_ENABLED: 'true'
-      DD_TRACE_ENABLED: 'true'
       DD_ENABLE_CAPI_METADATA_COLLECTION: 'true'
       TEST[KEY]: VALUE
     metadata:

--- a/examples/cf-php-sample-app/manifest.yml
+++ b/examples/cf-php-sample-app/manifest.yml
@@ -17,6 +17,7 @@ applications:
       STD_LOG_COLLECTION_PORT: 10514
       LOGS_CONFIG: '[{"type":"tcp","port":"10514","source":"php","service":"php-sample-app"}]'
       DD_PROFILING_ENABLED: 'true'
+      DD_APM_INSTRUMENTATION_ENABLED: 'true'
       DD_ENABLE_CAPI_METADATA_COLLECTION: 'true'
       TEST[KEY]: VALUE
     metadata:

--- a/examples/cf-php-sample-app/manifest.yml
+++ b/examples/cf-php-sample-app/manifest.yml
@@ -1,7 +1,7 @@
 ---
 applications:
   - name: php-sample-app
-    memory: 256M
+    memory: 1024M
     instances: 1
     path: .
     command: $HOME/php/bin/php -S 0.0.0.0:$PORT -t htdocs

--- a/examples/cf-php-sample-app/traffic
+++ b/examples/cf-php-sample-app/traffic
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+PORT=${PORT:-8080}
+LOCKFILE="/home/vcap/app/traffic_lock"
+
+main() {
+    exec 8> "${LOCKFILE}" || exit 1
+    if flock -x -n 8; then
+        while ! nc -z localhost $PORT; do
+            echo "Waiting for the server to start on $PORT"
+            sleep 2
+        done
+
+        while true; do
+            curl localhost:$PORT > /dev/null
+            sleep 5
+        done
+        exec 8>&-
+    fi
+}
+
+main "$@" > /home/vcap/app/traffic.log 2>&1


### PR DESCRIPTION
### What does this PR do?

Adds `examples/cf-php-sample-app/`, a new sample Cloud Foundry app demonstrating how to deploy and instrument a PHP application with the Datadog Cloud Foundry Buildpack — both APM tracing and continuous profiling.

Resolves [FRAGENT-3448](https://datadoghq.atlassian.net/browse/FRAGENT-3448).

### Release Notes

Add PHP sample app demonstrating APM tracing and profiling on Tanzu Application Service.

[FRAGENT-3448]: https://datadoghq.atlassian.net/browse/FRAGENT-3448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ