### PR TITLE
Fix logback/SLF4J mismatch in Java sample app

### DIFF
--- a/examples/cf-java-sample-app/pom.xml
+++ b/examples/cf-java-sample-app/pom.xml
@@ -30,7 +30,6 @@
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.5.32</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
The Java sample crashes at startup with `NoClassDefFoundError: org/slf4j/impl/StaticLoggerBinder`. Spring Boot 2.7.8 ships `slf4j-api 1.7.36`, which expects that class to come from `logback-classic 1.2.x`. The 1.5.32 pin from #256 requires SLF4J 2.x and dropped the class.

Dropping the explicit version so Spring Boot's BOM picks `logback-classic 1.2.11`, matching the `logback-core 1.2.11` and `slf4j-api 1.7.36` already on the classpath. Rebuilt the JAR locally to confirm.

#256 was opened for CVE-2023-6378, which 1.2.11 doesn't include (fix landed in 1.2.13). A follow-up pinning 1.2.13 would re-close the CVE without reintroducing this crash.