### PR TITLE
chore(ruby): bump embedded Ruby to 3.4.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 lib/dogstatsd
 lib/agent
 lib/trace-agent
-lib/ruby_3.0.5.tgz
+lib/ruby_3.4.7.tgz
 venv
 tmp
 .DS_Store

--- a/bin/compile
+++ b/bin/compile
@@ -23,7 +23,7 @@ RUBY_CMD=ruby
 # install ruby if needed (the case of cflinuxfs4 or custom stacks)
 if ! which ruby > /dev/null; then
   echo "Installing Ruby"
-  tar -xzf "${ROOT_DIR}/lib/ruby_3.0.5.tgz" -C "$DEPS_DIR/$DEPS_IDX" && echo "Ruby Install finished"
+  tar -xzf "${ROOT_DIR}/lib/ruby_3.4.7.tgz" -C "$DEPS_DIR/$DEPS_IDX" && echo "Ruby Install finished"
   export PATH=$PATH:/home/vcap/deps/$DEPS_IDX/bin
   RUBY_CMD=$DEPS_DIR/$DEPS_IDX/bin/ruby
 fi

--- a/bin/supply
+++ b/bin/supply
@@ -23,7 +23,7 @@ RUBY_CMD=ruby
 # install ruby if needed (the case of cflinuxfs4 or custom stacks)
 if ! which ruby > /dev/null; then
   echo "Installing Ruby"
-  tar -xzf "${ROOT_DIR}/lib/ruby_3.0.5.tgz" -C "$DEPS_DIR/$DEPS_IDX" && echo "Ruby Install finished"
+  tar -xzf "${ROOT_DIR}/lib/ruby_3.4.7.tgz" -C "$DEPS_DIR/$DEPS_IDX" && echo "Ruby Install finished"
   export PATH=$PATH:/home/vcap/deps/$DEPS_IDX/bin
   RUBY_CMD=$DEPS_DIR/$DEPS_IDX/bin/ruby
 fi

--- a/scripts/prepare.sh
+++ b/scripts/prepare.sh
@@ -51,7 +51,7 @@ function download_dogstatsd() {
 }
 
 function download_ruby() {
-  curl -LS "https://buildpacks.cloudfoundry.org/dependencies/ruby/ruby_3.0.5_linux_x64_cflinuxfs3_098393c3.tgz" -o  ${SRCDIR}/lib/ruby_3.0.5.tgz
+  curl -LS "https://buildpacks.cloudfoundry.org/dependencies/ruby/ruby_3.4.7_linux_x64_cflinuxfs3_72757c9c.tgz" -o  ${SRCDIR}/lib/ruby_3.4.7.tgz
 }
 
 function cleanup() {
@@ -74,7 +74,7 @@ function main() {
     rm -f ${SRCDIR}/lib/agent
     rm -f ${SRCDIR}/lib/dogstatsd
     rm -f ${SRCDIR}/lib/trace-agent
-    rm -f ${SRCDIR}/lib/ruby_3.0.5.tgz
+    rm -f ${SRCDIR}/lib/ruby_3.4.7.tgz
 
     # Download the new ones
     download_trace_agent ${VERSION}


### PR DESCRIPTION
## What does this PR do?
Bumps the embedded fallback Ruby tarball from `3.0.5` to `3.4.7` (cflinuxfs3 build from `buildpacks.cloudfoundry.org`). Updates `scripts/prepare.sh`, `bin/compile`, `bin/supply`, and `.gitignore`.

## Motivation
Ruby 3.0.5 reached EOL on 2024-03 and no longer receives security updates. Ruby 3.4.7 is in normal maintenance until 2028-03. This fallback Ruby is only used on stacks without a system Ruby (cflinuxfs4 or custom stacks).

## Verification
- Confirm the new tarball downloads: `REFRESH_ASSETS=true ./scripts/prepare.sh` produces `lib/ruby_3.4.7.tgz`.
- Confirm extraction path works on a cflinuxfs4 app push. `bin/supply` logs `Ruby Install finished` and `ruby version check: ruby 3.4.7`.
- Confirm `parse_env_vars.rb` and `get_tags.rb` still run against the new Ruby.