### PR TITLE
docs(php-sample-app): clarify build.sh is always required

### DIFF
--- a/examples/cf-php-sample-app/README.md
+++ b/examples/cf-php-sample-app/README.md
@@ -4,6 +4,6 @@ This App is an example of how to use the [Datadog Cloud Foundry Buildpack](https
 
 ## How to build and push
 
-1. Run `./build.sh` to vendor Composer dependencies into a local `vendor/` folder so the app can be staged on offline Cloud Foundry environments. The `dd-trace-php` native extensions are provided by the Datadog buildpack itself once `DD_APM_INSTRUMENTATION_ENABLED=true` is set.
+1. Run `./build.sh` to vendor Composer dependencies into a local `vendor/` folder. This is required because `htdocs/index.php` loads `../vendor/autoload.php`, while `php_buildpack`'s own `composer install` writes to `lib/vendor/` — and it also lets the app stage on offline Cloud Foundry environments. The `dd-trace-php` native extensions are provided by the Datadog buildpack itself once `DD_APM_INSTRUMENTATION_ENABLED=true` is set.
 2. Update the `manifest.yml` file with any other extra configuration options.
 3. Run `cf push --var DD_API_KEY=<API_KEY> --var ENV=<ENV_NAME>`, substituting `<API_KEY>` with your Datadog API key value.


### PR DESCRIPTION
The sample app's README currently frames `./build.sh` as needed *"so the app can be staged on offline Cloud Foundry environments"* — implying it's optional online. In practice it's **always required**, because `php_buildpack`'s own `composer install` writes to `lib/vendor/`, but `htdocs/index.php` loads `../vendor/autoload.php` (i.e. `./vendor/`). Without `build.sh` the app boots with `PHP Fatal error: Failed opening required '/home/vcap/app/htdocs/../vendor/autoload.php'`.

This PR tightens the wording to state the autoload requirement up front and keeps the offline-staging note as a secondary benefit.

Surfaced while verifying #257 on TAS 10.4 (bark-12516): an initial push without `build.sh` returned HTTP 500 for that exact reason.