### PR TITLE
docs(php): fix sample app README vendor path

### DIFF
--- a/examples/cf-php-sample-app/README.md
+++ b/examples/cf-php-sample-app/README.md
@@ -4,6 +4,6 @@ This App is an example of how to use the [Datadog Cloud Foundry Buildpack](https
 
 ## How to build and push
 
-1. Run `./build.sh` to vendor Composer dependencies into a local `vendor/` folder so the app can be staged on offline Cloud Foundry environments. The `dd-trace-php` native extensions are provided by the Datadog buildpack itself once `DD_APM_INSTRUMENTATION_ENABLED=true` is set.
+1. For offline Cloud Foundry environments, run `./build.sh` to vendor Composer dependencies into a local `lib/vendor/` folder so the app can stage without reaching packagist.org. Online environments can skip this step — `php_buildpack` runs `composer install` during staging. The `dd-trace-php` native extensions are provided by the Datadog buildpack itself once `DD_APM_INSTRUMENTATION_ENABLED=true` is set.
 2. Update the `manifest.yml` file with any other extra configuration options.
 3. Run `cf push --var DD_API_KEY=<API_KEY> --var ENV=<ENV_NAME>`, substituting `<API_KEY>` with your Datadog API key value.


### PR DESCRIPTION
## Summary
- Update the PHP sample app README to reference `lib/vendor/` instead of the stale `vendor/` path
- Clarify that `./build.sh` is only needed for offline staging; online `cf push` can rely on `php_buildpack` to run `composer install`

## Test plan
- [x] Verified `composer.json` sets `"vendor-dir": "lib/vendor"`
- [x] Verified `htdocs/index.php` requires `lib/vendor/autoload.php`


Made with [Cursor](https://cursor.com)