### PR TITLE
chore(php): use boolean env vars in sample manifest

### DIFF
--- a/examples/cf-php-sample-app/manifest.yml
+++ b/examples/cf-php-sample-app/manifest.yml
@@ -17,8 +17,8 @@ applications:
       STD_LOG_COLLECTION_PORT: 10514
       LOGS_CONFIG: '[{"type":"tcp","port":"10514","source":"php","service":"php-sample-app"}]'
       DD_PROFILING_ENABLED: true
-      DD_APM_INSTRUMENTATION_ENABLED: 'true'
-      DD_ENABLE_CAPI_METADATA_COLLECTION: 'true'
+      DD_APM_INSTRUMENTATION_ENABLED: true
+      DD_ENABLE_CAPI_METADATA_COLLECTION: true
       TEST[KEY]: VALUE
     metadata:
       labels:

--- a/examples/cf-php-sample-app/manifest.yml
+++ b/examples/cf-php-sample-app/manifest.yml
@@ -16,7 +16,7 @@ applications:
       DD_LOGS_ENABLED: true
       STD_LOG_COLLECTION_PORT: 10514
       LOGS_CONFIG: '[{"type":"tcp","port":"10514","source":"php","service":"php-sample-app"}]'
-      DD_PROFILING_ENABLED: 'true'
+      DD_PROFILING_ENABLED: true
       DD_APM_INSTRUMENTATION_ENABLED: 'true'
       DD_ENABLE_CAPI_METADATA_COLLECTION: 'true'
       TEST[KEY]: VALUE


### PR DESCRIPTION
## Summary
- Use bare `true` for all boolean env vars in the PHP sample app manifest:
  - `DD_PROFILING_ENABLED`
  - `DD_APM_INSTRUMENTATION_ENABLED`
  - `DD_ENABLE_CAPI_METADATA_COLLECTION`
- Aligns with `DD_LOGS_ENABLED` (already bare `true`) and with the Node.js/Java sample apps

## Test plan
- [x] Verified `run-datadog.sh` checks `[ "${DD_PROFILING_ENABLED:-}" = "true" ]`, which matches YAML boolean `true` when rendered as an env var
- [x] Verified `DD_APM_INSTRUMENTATION_ENABLED` and `DD_ENABLE_CAPI_METADATA_COLLECTION` use the same string comparison pattern elsewhere in the buildpack